### PR TITLE
Expose mute function

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -164,6 +164,7 @@ class Chromecast(object):
 
         # Forward these methods
         self.set_volume = self.socket_client.receiver_controller.set_volume
+        self.set_volume_muted = self.socket_client.receiver_controller.set_volume_muted
         self.play_media = self.socket_client.media_controller.play_media
         self.register_handler = self.socket_client.register_handler
 
@@ -224,6 +225,11 @@ class Chromecast(object):
         """
         volume = round(self.status.volume_level, 1)
         return self.set_volume(volume - 0.1)
+
+    def volume_mute(self, mute):
+        """ Mute the volume if mute is true
+        or unmute if the mute parameter is false. """
+        self.set_volume_muted(mute)
 
     def __del__(self):
         self.socket_client.stop.set()

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -226,11 +226,6 @@ class Chromecast(object):
         volume = round(self.status.volume_level, 1)
         return self.set_volume(volume - 0.1)
 
-    def volume_mute(self, mute):
-        """ Mute the volume if mute is true
-        or unmute if the mute parameter is false. """
-        self.set_volume_muted(mute)
-
     def __del__(self):
         self.socket_client.stop.set()
 

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -163,8 +163,9 @@ class Chromecast(object):
         self.socket_client.receiver_controller.register_status_listener(self)
 
         # Forward these methods
-        self.set_volume = self.socket_client.receiver_controller.set_volume
-        self.set_volume_muted = self.socket_client.receiver_controller.set_volume_muted
+        receiver_controller = self.socket_client.receiver_controller
+        self.set_volume = receiver_controller.set_volume
+        self.set_volume_muted = receiver_controller.set_volume_muted
         self.play_media = self.socket_client.media_controller.play_media
         self.register_handler = self.socket_client.register_handler
 

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -160,10 +160,10 @@ class Chromecast(object):
 
         self.socket_client = socket_client.SocketClient(host, tries)
 
-        self.socket_client.receiver_controller.register_status_listener(self)
+        receiver_controller = self.socket_client.receiver_controller
+        receiver_controller.register_status_listener(self)
 
         # Forward these methods
-        receiver_controller = self.socket_client.receiver_controller
         self.set_volume = receiver_controller.set_volume
         self.set_volume_muted = receiver_controller.set_volume_muted
         self.play_media = self.socket_client.media_controller.play_media


### PR DESCRIPTION
I exposed your mute function (so that it can be called from Home Assistant), but that will require another upload to pypi..

Can you have a look at https://github.com/balloob/pychromecast/blob/45c7dff0600c87be0bb8a0d5a1618a7897f232da/pychromecast/__init__.py#L166-167 whether and how those functions should be exposed?

Since I'm not familiar with Python I'm not sure what is a good practice (in C# this "just adding functions to an object" like how it's done with set_volume is not possible).

set_volume is not in the Chromecast object signature, but I use it from https://github.com/balloob/home-assistant/blob/dev/homeassistant/components/media_player/cast.py#L165

I added set_volume_muted to the Chromecast object signature now.