### PR TITLE
Added Ignore CEC Capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ The following instructions require the use of the [Google Chrome browser](https:
  * Go through the results and collect the JSON that is exchanged.
  * Now write a controller that is able to mimic this behavior :-)
 
+Ignoring CEC Data
+-----------------
+The Chromecast typically reports whether it is the active input on the device
+to which it is connected. This value is stored inside a cast object in the
+following property.
+
+    cast.status.is_active_input
+
+Some Chromecast users have reported CEC incompatibilities with their media
+center devices. These incompatibilities may sometimes cause this active input
+value to be reported improperly.
+
+This active input value is typically used to determine if the Chromecast is
+idle. PyChromecast is capable of ignoring the active input value when
+determining in the Chromecast is idle in the instance that the Chromecast is
+returning erroneous values. To ignore this CEC detection data in PyChromecast,
+append a [Linux style wildcard](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)
+formatted string to the IGNORE_CEC list in PyChromecast like in the example
+below.
+
+    pychromecast.IGNORE_CEC.append('*')  # Ignore CEC on all devices
+    pychromecast.IGNORE_CEC.append('Living Room')  # Ignore CEC on Chromecasts named Living Room
+
 Thanks
 ------
 I would like to thank [Fred Clift](https://github.com/minektur) for laying the socket client ground work. Without him it would not have been possible!

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ value to be reported improperly.
 
 This active input value is typically used to determine if the Chromecast is
 idle. PyChromecast is capable of ignoring the active input value when
-determining in the Chromecast is idle in the instance that the Chromecast is
+determining if the Chromecast is idle in the instance that the Chromecast is
 returning erroneous values. To ignore this CEC detection data in PyChromecast,
 append a [Linux style wildcard](http://tldp.org/LDP/GNU-Linux-Tools-Summary/html/x11655.htm)
 formatted string to the IGNORE_CEC list in PyChromecast like in the example

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -175,6 +175,7 @@ class Chromecast(object):
 
     @property
     def ignore_cec(self):
+        """ Returns whether the CEC data should be ignored. """
         return self.device is not None and \
             any([fnmatch.fnmatchcase(self.device.friendly_name, pattern)
                  for pattern in IGNORE_CEC])

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -4,6 +4,7 @@ PyChromecast: remote control your Chromecast
 from __future__ import print_function
 
 import logging
+import fnmatch
 
 # pylint: disable=wildcard-import
 from .config import *  # noqa
@@ -14,6 +15,7 @@ from .dial import get_device_status, reboot
 from .controllers.media import STREAM_TYPE_BUFFERED  # noqa
 
 IDLE_APP_ID = 'E8C28D3C'
+IGNORE_CEC = []
 
 
 def _get_all_chromecasts(tries=None):
@@ -172,10 +174,17 @@ class Chromecast(object):
         self.socket_client.start()
 
     @property
+    def ignore_cec(self):
+        return self.device is not None and \
+            any([fnmatch.fnmatchcase(self.device.friendly_name, pattern)
+                 for pattern in IGNORE_CEC])
+
+    @property
     def is_idle(self):
         """ Returns if there is currently an app running. """
-        return (self.status is None or not self.status.is_active_input or
-                self.app_id in (None, IDLE_APP_ID))
+        return (self.status is None or
+                self.app_id in (None, IDLE_APP_ID) or
+                (not self.status.is_active_input and not self.ignore_cec))
 
     @property
     def app_id(self):


### PR DESCRIPTION
Added the ability to ignore CEC information from the Chromecast if it is returning incorrect data. This is to address issue #50.

Also, [happy birthday Paulus!](https://www.youtube.com/watch?v=KKfNYmNdiF0)