### PR TITLE
Added wait() method to make it easier to wait for the initial status

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -159,6 +159,7 @@ class Chromecast(object):
                 "Could not connect to {}".format(self.host))
 
         self.status = None
+        self.status_event = threading.Event()
 
         self.socket_client = socket_client.SocketClient(host, tries)
 
@@ -205,6 +206,7 @@ class Chromecast(object):
     def new_cast_status(self, status):
         """ Called when a new status received from the Chromecast. """
         self.status = status
+        self.status_event.set()
 
     def start_app(self, app_id):
         """ Start an app on the Chromecast. """
@@ -249,7 +251,7 @@ class Chromecast(object):
                         operation in seconds (or fractions thereof). Or None
                         to block forever.
         """
-        self.socket_client.receiver_controller.wait_for_status(timeout=timeout)
+        self.status_event.wait(timeout=timeout)
 
     def disconnect(self, timeout=None, blocking=True):
         """

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -7,6 +7,7 @@ import logging
 import fnmatch
 
 # pylint: disable=wildcard-import
+import threading
 from .config import *  # noqa
 from .error import *  # noqa
 from . import socket_client

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -237,6 +237,20 @@ class Chromecast(object):
         volume = round(self.status.volume_level, 1)
         return self.set_volume(volume - 0.1)
 
+    def wait(self, timeout=None):
+        """
+        Waits until the cast device is ready for communication. The device
+        is ready as soon a status message has been received.
+
+        If the status has already been received then the method returns
+        immediately.
+
+        :param timeout: a floating point number specifying a timeout for the
+                        operation in seconds (or fractions thereof). Or None
+                        to block forever.
+        """
+        self.socket_client.receiver_controller.wait_for_status(timeout=timeout)
+
     def disconnect(self, timeout=None, blocking=True):
         """
         Disconnects the chromecast and waits for it to terminate.

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -601,7 +601,6 @@ class ReceiverController(BaseController):
             NS_RECEIVER, target_platform=True)
 
         self.status = None
-        self.status_event = threading.Event()
         self.launch_failure = None
         self.app_to_launch = None
         self.app_launch_event = threading.Event()
@@ -613,21 +612,6 @@ class ReceiverController(BaseController):
     def app_id(self):
         """ Convenience method to retrieve current app id. """
         return self.status.app_id if self.status else None
-
-    def wait_for_status(self, timeout=None):
-        """
-        Waits until a status value is available from the cast device.
-        This can be used directly after receiving a cast object to halt
-        execution until the status message has been received.
-
-        If the status has already been received then the method returns
-        immediately.
-
-        :param timeout: a floating point number specifying a timeout for the
-                        operation in seconds (or fractions thereof). Or None
-                        to block forever.
-        """
-        self.status_event.wait(timeout=timeout)
 
     def receive_message(self, message, data):
         """ Called when a receiver-message has been received. """
@@ -787,8 +771,6 @@ class ReceiverController(BaseController):
                 listener.new_cast_status(self.status)
             except Exception:  # pylint: disable=broad-except
                 pass
-
-        self.status_event.set()
 
     @staticmethod
     def _parse_launch_error(data):

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -601,6 +601,7 @@ class ReceiverController(BaseController):
             NS_RECEIVER, target_platform=True)
 
         self.status = None
+        self.status_event = threading.Event()
         self.launch_failure = None
         self.app_to_launch = None
         self.app_launch_event = threading.Event()
@@ -612,6 +613,21 @@ class ReceiverController(BaseController):
     def app_id(self):
         """ Convenience method to retrieve current app id. """
         return self.status.app_id if self.status else None
+
+    def wait_for_status(self, timeout=None):
+        """
+        Waits until a status value is available from the cast device.
+        This can be used directly after receiving a cast object to halt
+        execution until the status message has been received.
+
+        If the status has already been received then the method returns
+        immediately.
+
+        :param timeout: a floating point number specifying a timeout for the
+                        operation in seconds (or fractions thereof). Or None
+                        to block forever.
+        """
+        self.status_event.wait(timeout=timeout)
 
     def receive_message(self, message, data):
         """ Called when a receiver-message has been received. """
@@ -771,6 +787,8 @@ class ReceiverController(BaseController):
                 listener.new_cast_status(self.status)
             except Exception:  # pylint: disable=broad-except
                 pass
+
+        self.status_event.set()
 
     @staticmethod
     def _parse_launch_error(data):


### PR DESCRIPTION
This removes the need to make a custom status listener that waits for
the initial status message. Once the status message has been received
the method will return, if a status is already present it returns
immediately.

The caller must do a:
```python
  cast = pychromecast.get_chromecast()
  cast.wait()
```
right after receiving the cast object.

This could help out with solving issue #40.

Open for a better name for the method.