### PR TITLE
unicode fix

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -29,7 +29,9 @@ def get_device_status(host):
             FORMAT_BASE_URL.format(host) + "/ssdp/device-desc.xml",
             timeout=10)
 
-        req.encoding = "utf-8"
+        if req.encoding is None:
+            req.encoding = "utf-8" # don't attempt to guess
+            
         status_el = ET.fromstring(req.text.encode("UTF-8"))
 
         device_info_el = status_el.find(XML_NS_UPNP_DEVICE + "device")

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -29,9 +29,15 @@ def get_device_status(host):
             FORMAT_BASE_URL.format(host) + "/ssdp/device-desc.xml",
             timeout=10)
 
+        # The Requests library will fall back to guessing the encoding in case
+        # no encoding is specified in the response headers - which is the case
+        # for the Chromecast.
+        # The standard mandates utf-8 encoding, let's fall back to that instead
+        # if no encoding is provided, since the autodetection does not always
+        # provide correct results.
         if req.encoding is None:
-            req.encoding = "utf-8" # don't attempt to guess
-            
+            req.encoding = 'utf-8'
+
         status_el = ET.fromstring(req.text.encode("UTF-8"))
 
         device_info_el = status_el.find(XML_NS_UPNP_DEVICE + "device")

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -29,6 +29,7 @@ def get_device_status(host):
             FORMAT_BASE_URL.format(host) + "/ssdp/device-desc.xml",
             timeout=10)
 
+        req.encoding = "utf-8"
         status_el = ET.fromstring(req.text.encode("UTF-8"))
 
         device_info_el = status_el.find(XML_NS_UPNP_DEVICE + "device")


### PR DESCRIPTION
Explicitly set the encoding of the response to UTF-8, which it (what I understand from the standard) should be anyway.

I don't know about the new Chromecast, but my first generation Chromecast doesn't return any encoding in the HTTP response. Example: {'Content-Length': '1100', 'Application-URL': '<url>', 'Content-Type': 'application/xml'}, and it seems like the fallback to guessing the encoding fails, since the response containing UTF-8 encoded Swedish characters (the assigned name of my Chromecast) gets detected as iso-8859-2

The DIAL specification, 6.1.2 Server Response: "The MIME type of the response SHALL be text/xmland the character encoding SHALL be UTF-8 and SHALL be explicitly indicated with the charsetMIME parameter."

The requests library, Encodings (http://docs.python-requests.org/en/latest/user/advanced/#encodings): "When you receive a response, Requests makes a guess at the encoding to use for decoding the response when you access the Response.text attribute. Requests will first check for an encoding in the HTTP header, and if none is present, will use chardet to attempt to guess the encoding."