### PR TITLE
Add metadata support to default media receiver

### DIFF
--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -396,8 +396,27 @@ class MediaController(BaseController):
                    current_time=0, autoplay=True,
                    stream_type=STREAM_TYPE_BUFFERED,
                    metadata=None):
-        """ Plays media on the Chromecast. Start default media receiver if not
-            already started. """
+        """
+        Plays media on the Chromecast. Start default media receiver if not
+        already started.
+
+        Parameters:
+        url: str - url of the media.
+        content_type: str - mime type. Example: 'video/mp4'.
+        title: str - title of the media.
+        thumb: str - thumbnail image url.
+        current_time: float - seconds from the beginning of the media
+            to start playback.
+        autoplay: bool - whether the media will automatically play.
+        stream_type: str - describes the type of media artifact as one of the
+            following: "NONE", "BUFFERED", "LIVE".
+        metadata: dict - media metadata object, one of the following:
+            GenericMediaMetadata, MovieMediaMetadata, TvShowMediaMetadata,
+            MusicTrackMediaMetadata, PhotoMediaMetadata.
+
+        Docs:
+        https://developers.google.com/cast/docs/reference/messages#MediaData
+        """
 
         self._socket_client.receiver_controller.launch_app(APP_MEDIA_RECEIVER)
 

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -394,7 +394,8 @@ class MediaController(BaseController):
     # pylint: disable=too-many-arguments
     def play_media(self, url, content_type, title=None, thumb=None,
                    current_time=0, autoplay=True,
-                   stream_type=STREAM_TYPE_BUFFERED):
+                   stream_type=STREAM_TYPE_BUFFERED,
+                   metadata=None):
         """ Plays media on the Chromecast. Start default media receiver if not
             already started. """
 
@@ -423,6 +424,9 @@ class MediaController(BaseController):
                 msg['customData']['payload'] = {}
 
             msg['customData']['payload']['thumb'] = thumb
+
+        if metadata:
+            msg['media']['metadata'] = metadata
 
         self.send_message(msg, inc_session_id=True)
 


### PR DESCRIPTION
I added extra parameter metadata to play_media() method of MediaController.

Example of usage:
```python
import pychromecast
cast = pychromecast.get_chromecast()
metadata = {
    "metadataType": 0,
    "title": "Big Buck Bunny",
    "images": [
        {"url": "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"}
    ]
}
cast.media_controller.play_media(
    'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
    'video/mp4',
    metadata=metadata
)
```
Here is a full doc [https://developers.google.com/cast/docs/reference/messages#MediaData](https://developers.google.com/cast/docs/reference/messages#MediaData)

Hope it will be useful for someone.