### PR TITLE
Fix typo: 'Plex' -> 'Youtube'

### DIFF
--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -11,7 +11,7 @@ ATTR_SCREEN_ID = "screenId"
 
 
 class YouTubeController(BaseController):
-    """ Controller to interact with Plex namespace. """
+    """ Controller to interact with Youtube namespace. """
 
     def __init__(self):
         super(YouTubeController, self).__init__(


### PR DESCRIPTION
This just fixes a trivial typo in a comment.