### PR TITLE
Specify volume delta.

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -349,20 +349,20 @@ class Chromecast(object):
         """ Reboots the Chromecast. """
         reboot(self.host)
 
-    def volume_up(self):
-        """ Increment volume by 0.1 unless it is already maxed.
+    def volume_up(self, delta=0.1):
+        """ Increment volume by 0.1 (or delta) unless it is already maxed.
         Returns the new volume.
 
         """
-        volume = round(self.status.volume_level, 1)
-        return self.set_volume(volume + 0.1)
+        volume = round(self.status.volume_level, 2)
+        return self.set_volume(volume + delta)
 
-    def volume_down(self):
-        """ Decrement the volume by 0.1 unless it is already 0.
+    def volume_down(self, delta=0.1):
+        """ Decrement the volume by 0.1 (or delta) unless it is already 0.
         Returns the new volume.
         """
-        volume = round(self.status.volume_level, 1)
-        return self.set_volume(volume - 0.1)
+        volume = round(self.status.volume_level, 2)
+        return self.set_volume(volume - delta)
 
     def wait(self, timeout=None):
         """

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -354,13 +354,17 @@ class Chromecast(object):
         Returns the new volume.
 
         """
-        return self.set_volume(self.status.volume_level + abs(delta))
+        if delta <= 0:
+            raise ValueError("volume delta must be greater than zero, not {}".format(delta))
+        return self.set_volume(self.status.volume_level + delta)
 
     def volume_down(self, delta=0.1):
         """ Decrement the volume by 0.1 (or delta) unless it is already 0.
         Returns the new volume.
         """
-        return self.set_volume(self.status.volume_level - abs(delta))
+        if delta <= 0:
+            raise ValueError("volume delta must be greater than zero, not {}".format(delta))
+        return self.set_volume(self.status.volume_level - delta)
 
     def wait(self, timeout=None):
         """

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -360,7 +360,6 @@ class Chromecast(object):
         """ Decrement the volume by 0.1 (or delta) unless it is already 0.
         Returns the new volume.
         """
-        import sys
         return self.set_volume(self.status.volume_level - abs(delta))
 
     def wait(self, timeout=None):

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -355,7 +355,8 @@ class Chromecast(object):
 
         """
         if delta <= 0:
-            raise ValueError("volume delta must be greater than zero, not {}".format(delta))
+            raise ValueError(
+                "volume delta must be greater than zero, not {}".format(delta))
         return self.set_volume(self.status.volume_level + delta)
 
     def volume_down(self, delta=0.1):
@@ -363,7 +364,8 @@ class Chromecast(object):
         Returns the new volume.
         """
         if delta <= 0:
-            raise ValueError("volume delta must be greater than zero, not {}".format(delta))
+            raise ValueError(
+                "volume delta must be greater than zero, not {}".format(delta))
         return self.set_volume(self.status.volume_level - delta)
 
     def wait(self, timeout=None):

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -354,15 +354,14 @@ class Chromecast(object):
         Returns the new volume.
 
         """
-        volume = round(self.status.volume_level, 2)
-        return self.set_volume(volume + delta)
+        return self.set_volume(self.status.volume_level + abs(delta))
 
     def volume_down(self, delta=0.1):
         """ Decrement the volume by 0.1 (or delta) unless it is already 0.
         Returns the new volume.
         """
-        volume = round(self.status.volume_level, 2)
-        return self.set_volume(volume - delta)
+        import sys
+        return self.set_volume(self.status.volume_level - abs(delta))
 
     def wait(self, timeout=None):
         """


### PR DESCRIPTION
Allow the user to specify the delta value for `volume_up()` and `volume_down()`.

(I find the hardwired delta of `0.1` too coarse for my own set up.)
