### PR TITLE
Ignore benign error in destructor. Fix #113

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -404,7 +404,10 @@ class Chromecast(object):
         self.socket_client.join(timeout=timeout)
 
     def __del__(self):
-        self.socket_client.stop.set()
+        try:
+            self.socket_client.stop.set()
+        except AttributeError:
+            pass
 
     def __repr__(self):
         txt = u"Chromecast({!r}, port={!r}, device={!r})".format(


### PR DESCRIPTION
It’s not really an issue, but when the Chromecast object gets garbage
collected after failing to connect to a device (before creating a
SocketClient instance), its __del__ is called, which in turn calls
`self.socket_client.stop.set()`. This leads to the error described in
the mentioned issue being logged/printed.