### PR TITLE
Add buffering state to media player

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -22,7 +22,7 @@ __all__ = (
     'get_chromecasts', 'get_chromecasts_as_dict', 'get_chromecast',
     'Chromecast'
 )
-__version_info__ = ('0', '7', '1')
+__version_info__ = ('0', '7', '6')
 __version__ = '.'.join(__version_info__)
 
 IDLE_APP_ID = 'E8C28D3C'

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -12,6 +12,7 @@ STREAM_TYPE_BUFFERED = "BUFFERED"
 STREAM_TYPE_LIVE = "LIVE"
 
 MEDIA_PLAYER_STATE_PLAYING = "PLAYING"
+MEDIA_PLAYER_STATE_BUFFERING = "BUFFERING"
 MEDIA_PLAYER_STATE_PAUSED = "PAUSED"
 MEDIA_PLAYER_STATE_IDLE = "IDLE"
 MEDIA_PLAYER_STATE_UNKNOWN = "UNKNOWN"
@@ -73,7 +74,8 @@ class MediaStatus(object):
     @property
     def player_is_playing(self):
         """ Return True if player is PLAYING. """
-        return self.player_state == MEDIA_PLAYER_STATE_PLAYING
+        return (self.player_state == MEDIA_PLAYER_STATE_PLAYING or
+                self.player_state == MEDIA_PLAYER_STATE_BUFFERING)
 
     @property
     def player_is_paused(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open('README.rst').read()
 
 setup(
     name='PyChromecast',
-    version='0.7.5',
+    version='0.7.6',
     license='MIT',
     url='https://github.com/balloob/pychromecast',
     author='Paulus Schoutsen',


### PR DESCRIPTION
During playback, my chromecast fairly frequently reports a buffering state
although playback is uninterrupted. Because this state was previously unknown,
home-assistant would report an "off" state for the device.

This fills up the logbook/history with many unnecessary state transitions.
Treating buffering as playing avoids these transitions.