### PR TITLE
Catch more general exception

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -80,7 +80,7 @@ def _json_from_message(message):
     """ Parses a PB2 message into JSON format. """
     try:
         return json.loads(message.payload_utf8)
-    except json.decoder.JSONDecodeError:
+    except ValueError:
         logger = logging.getLogger(__name__)
         logger.warning("Ignoring invalid json in namespace %s: %s",
                        message.namespace, message.payload_utf8)


### PR DESCRIPTION
catch more generic ValueError since different json implementations seems to raise either ValueError, json.JSONDecodeError or json.decoder.JSONDecodeError