### PR TITLE
Support own main loop and non-blocking functions

### DIFF
--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -1,5 +1,8 @@
 """
 Example that shows how the new Python 2 socket client can be used.
+
+Functions called in this example are blocking which means that
+the function doesn't return as long as no result was received.
 """
 
 from __future__ import print_function

--- a/examples/non_blocking.py
+++ b/examples/non_blocking.py
@@ -1,0 +1,82 @@
+"""
+Example that shows how the new Python 2 socket client can be used.
+
+All functions (except get_chromecast()) are non-blocking and
+return immediately without waiting for the result. You can use
+that functionality to include pychromecast into your main loop.
+"""
+
+from __future__ import print_function
+import time
+import select
+import sys
+import logging
+
+import pychromecast
+
+"""
+Put this code into your startup/init code.
+This one is the only blocking part.
+"""
+def initialize_chromecast():
+    print("Initialize Chromecast (blocking)...takes some time")
+    cast = pychromecast.get_chromecast(friendly_name="Wohnzimmer",
+                                       blocking=False)
+    return cast
+
+"""
+Check for cast.socket_client.get_socket() and
+handle it with cast.socket_client.run_once()
+"""
+def your_main_loop(cast):
+    t = 1
+    while True:
+        polltime = 0.1
+        can_read, _, _ = select.select([cast.socket_client.get_socket()], [], [], polltime)
+        if can_read:
+            #received something on the socket, handle it with run_once()
+            cast.socket_client.run_once()
+        do_actions(cast, t)
+        time.sleep(1)
+        t += 1
+        if(t > 50):
+           break
+
+"""
+Your code which is called by main loop
+"""
+def do_actions(cast, t):
+    if t == 5:
+        print()
+        print("=> Sending non-blocking play_media command")
+        cast.play_media(
+            ("http://commondatastorage.googleapis.com/gtv-videos-bucket/"
+             "sample/BigBuckBunny.mp4"), "video/mp4")
+    elif t == 30:
+        print()
+        print("=> Sending non-blocking pause command")
+        cast.media_controller.pause()
+    elif t == 35:
+        print()
+        print("=> Sending non-blocking play command")
+        cast.media_controller.play()
+    elif t == 40:
+        print()
+        print("=> Sending non-blocking stop command")
+        cast.media_controller.stop()
+    elif t == 45:
+        print()
+        print("=> Sending non-blocking quit_app command")
+        cast.quit_app()
+    elif t % 4 == 0:
+        print()
+        print("Media status", cast.media_controller.status)
+
+if '--show-debug' in sys.argv:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.INFO)
+
+cast = initialize_chromecast()
+your_main_loop(cast)
+

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -1,4 +1,3 @@
-
 """
 PyChromecast: remote control your Chromecast
 """
@@ -62,7 +61,8 @@ def _get_all_chromecasts(tries=None, retry_wait=None, timeout=None,
     return cc_list
 
 
-def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True, **filters):
+def get_chromecasts(tries=None, retry_wait=None, timeout=None,
+                    blocking=True, **filters):
     """
     Searches the network and returns a list of Chromecast objects.
     Filter is a list of options to filter the chromecasts by.
@@ -116,7 +116,7 @@ def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True, **
 
 
 def get_chromecasts_as_dict(tries=None, retry_wait=None, timeout=None,
-                            **filters):
+                            blocking=True, **filters):
     """
     Returns a dictionary of chromecasts with the friendly name as
     the key.  The value is the pychromecast object itself.
@@ -130,7 +130,7 @@ def get_chromecasts_as_dict(tries=None, retry_wait=None, timeout=None,
     """
     return {cc.device.friendly_name: cc
             for cc in get_chromecasts(tries=tries, retry_wait=retry_wait,
-                                      timeout=timeout,
+                                      timeout=timeout, blocking,
                                       **filters)}
 
 

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -1,3 +1,4 @@
+
 """
 PyChromecast: remote control your Chromecast
 """
@@ -61,8 +62,7 @@ def _get_all_chromecasts(tries=None, retry_wait=None, timeout=None,
     return cc_list
 
 
-def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True,
-                    **filters):
+def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True, **filters):
     """
     Searches the network and returns a list of Chromecast objects.
     Filter is a list of options to filter the chromecasts by.
@@ -88,8 +88,7 @@ def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True,
     """
     logger = logging.getLogger(__name__)
 
-    cc_list = set(_get_all_chromecasts(tries, retry_wait,
-                                       timeout, blocking))
+    cc_list = set(_get_all_chromecasts(tries, retry_wait, timeout, blocking))
     excluded_cc = set()
 
     if not filters:

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -130,7 +130,7 @@ def get_chromecasts_as_dict(tries=None, retry_wait=None, timeout=None,
     """
     return {cc.device.friendly_name: cc
             for cc in get_chromecasts(tries=tries, retry_wait=retry_wait,
-                                      timeout=timeout, blocking,
+                                      timeout=timeout, blocking=blocking,
                                       **filters)}
 
 

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -31,7 +31,8 @@ IGNORE_CEC = []
 NON_UNICODE_REPR = sys.version_info < (3, )
 
 
-def _get_all_chromecasts(tries=None, retry_wait=None, timeout=None):
+def _get_all_chromecasts(tries=None, retry_wait=None, timeout=None,
+                         blocking=True):
     """
     Returns a list of all chromecasts on the network as PyChromecast
     objects.
@@ -53,13 +54,15 @@ def _get_all_chromecasts(tries=None, retry_wait=None, timeout=None):
             cc_list.append(Chromecast(host=ip_address, port=port,
                                       device=device,
                                       tries=tries, timeout=timeout,
-                                      retry_wait=retry_wait))
+                                      retry_wait=retry_wait,
+                                      blocking=blocking))
         except ChromecastConnectionError:  # noqa
             pass
     return cc_list
 
 
-def get_chromecasts(tries=None, retry_wait=None, timeout=None, **filters):
+def get_chromecasts(tries=None, retry_wait=None, timeout=None, blocking=True,
+                    **filters):
     """
     Searches the network and returns a list of Chromecast objects.
     Filter is a list of options to filter the chromecasts by.
@@ -85,7 +88,8 @@ def get_chromecasts(tries=None, retry_wait=None, timeout=None, **filters):
     """
     logger = logging.getLogger(__name__)
 
-    cc_list = set(_get_all_chromecasts(tries, retry_wait, timeout))
+    cc_list = set(_get_all_chromecasts(tries, retry_wait,
+                                       timeout, blocking))
     excluded_cc = set()
 
     if not filters:
@@ -132,7 +136,7 @@ def get_chromecasts_as_dict(tries=None, retry_wait=None, timeout=None,
 
 
 def get_chromecast(strict=False, tries=None, retry_wait=None, timeout=None,
-                   **filters):
+                   blocking=True, **filters):
     """
     Same as get_chromecasts but only if filter matches exactly one
     ChromeCast.
@@ -156,10 +160,11 @@ def get_chromecast(strict=False, tries=None, retry_wait=None, timeout=None,
     # If no filters given and not strict just use the first dicsovered one.
     if filters or strict:
         results = get_chromecasts(tries=tries, retry_wait=retry_wait,
-                                  timeout=timeout,
+                                  timeout=timeout, blocking=blocking,
                                   **filters)
     else:
-        results = _get_all_chromecasts(tries, retry_wait)
+        results = _get_all_chromecasts(tries, retry_wait,
+                                       blocking=blocking)
 
     if len(results) > 1:
         if strict:
@@ -204,6 +209,7 @@ class Chromecast(object):
         tries = kwargs.pop('tries', None)
         timeout = kwargs.pop('timeout', None)
         retry_wait = kwargs.pop('retry_wait', None)
+        blocking = kwargs.pop('blocking', True)
 
         self.logger = logging.getLogger(__name__)
 
@@ -248,7 +254,8 @@ class Chromecast(object):
 
         self.socket_client = socket_client.SocketClient(
             host, port=port, cast_type=self.device.cast_type,
-            tries=tries, timeout=timeout, retry_wait=retry_wait)
+            tries=tries, timeout=timeout, retry_wait=retry_wait,
+            blocking=blocking)
 
         receiver_controller = self.socket_client.receiver_controller
         receiver_controller.register_status_listener(self)
@@ -265,7 +272,8 @@ class Chromecast(object):
         self.register_connection_listener = \
             self.socket_client.register_connection_listener
 
-        self.socket_client.start()
+        if blocking:
+            self.socket_client.start()
 
     @property
     def ignore_cec(self):

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -36,12 +36,12 @@ class BaseController(object):
         return (self._socket_client is not None and
                 self.namespace in self._socket_client.app_namespaces)
 
-    def launch(self, callback_function=None):
+    def launch(self, callback_function):
         """ If set, launches app related to the controller. """
         self._check_registered()
 
         self._socket_client.receiver_controller.launch_app(
-            self.supporting_app_id, callback_function=callback_function)
+            self.supporting_app_id,callback_function=callback_function)
 
     def registered(self, socket_client):
         """ Called when a controller is registered. """
@@ -62,7 +62,7 @@ class BaseController(object):
         pass
 
     def send_message(self, data, inc_session_id=False,
-                     callback_function=None):
+                     callback_function=False):
         """
         Send a message on this namespace to the Chromecast.
 

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -36,7 +36,7 @@ class BaseController(object):
         return (self._socket_client is not None and
                 self.namespace in self._socket_client.app_namespaces)
 
-    def launch(self, callback_function):
+    def launch(self, callback_function=None):
         """ If set, launches app related to the controller. """
         self._check_registered()
 

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -62,7 +62,7 @@ class BaseController(object):
         pass
 
     def send_message(self, data, inc_session_id=False,
-                     callback_function=False):
+                     callback_function=None):
         """
         Send a message on this namespace to the Chromecast.
 

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -36,12 +36,12 @@ class BaseController(object):
         return (self._socket_client is not None and
                 self.namespace in self._socket_client.app_namespaces)
 
-    def launch(self, callback_function):
+    def launch(self, callback_function=None):
         """ If set, launches app related to the controller. """
         self._check_registered()
 
         self._socket_client.receiver_controller.launch_app(
-            self.supporting_app_id,callback_function=callback_function)
+            self.supporting_app_id, callback_function=callback_function)
 
     def registered(self, socket_client):
         """ Called when a controller is registered. """
@@ -62,7 +62,7 @@ class BaseController(object):
         pass
 
     def send_message(self, data, inc_session_id=False,
-                     callback_function=False):
+                     callback_function=None):
         """
         Send a message on this namespace to the Chromecast.
 

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -41,7 +41,7 @@ class BaseController(object):
         self._check_registered()
 
         self._socket_client.receiver_controller.launch_app(
-            self.supporting_app_id,callback_function=callback_function)
+            self.supporting_app_id, callback_function=callback_function)
 
     def registered(self, socket_client):
         """ Called when a controller is registered. """

--- a/pychromecast/controllers/__init__.py
+++ b/pychromecast/controllers/__init__.py
@@ -36,12 +36,12 @@ class BaseController(object):
         return (self._socket_client is not None and
                 self.namespace in self._socket_client.app_namespaces)
 
-    def launch(self):
+    def launch(self, callback_function):
         """ If set, launches app related to the controller. """
         self._check_registered()
 
         self._socket_client.receiver_controller.launch_app(
-            self.supporting_app_id)
+            self.supporting_app_id,callback_function=callback_function)
 
     def registered(self, socket_client):
         """ Called when a controller is registered. """
@@ -62,7 +62,7 @@ class BaseController(object):
         pass
 
     def send_message(self, data, inc_session_id=False,
-                     wait_for_response=False):
+                     callback_function=False):
         """
         Send a message on this namespace to the Chromecast.
 
@@ -81,7 +81,7 @@ class BaseController(object):
                      "application.").format(self.namespace))
 
         return self._message_func(
-            self.namespace, data, inc_session_id, wait_for_response)
+            self.namespace, data, inc_session_id, callback_function)
 
     # pylint: disable=unused-argument,no-self-use
     def receive_message(self, message, data):

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -428,24 +428,19 @@ class MediaController(BaseController):
         https://developers.google.com/cast/docs/reference/messages#MediaData
         """
 
-        receiver_ctrl = self._socket_client.receiver_controller
-        receiver_ctrl.launch_app(self.app_id,
-                                 callback_function=lambda response:
-                                 self._send_start_play_media(url, content_type,
-                                                             title, thumb,
-                                                             current_time, autoplay,
-                                                             stream_type,
-                                                             metadata, subtitles,
-                                                             subtitles_lang,
-                                                             subtitles_mime,
-                                                             subtitle_id))
+        self._socket_client.receiver_controller.launch_app(self.app_id,
+                   callback_function=lambda: self._send_start_play_media(url, content_type,
+                                                                         title, thumb,
+                                                                         current_time, autoplay,
+                                                                         stream_type,
+                                                                         metadata, subtitles, subtitles_lang,
+                                                                         subtitles_mime, subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
-                               current_time=0, autoplay=True,
-                               stream_type=STREAM_TYPE_BUFFERED,
-                               metadata=None, subtitles=None,
-                               subtitles_lang='en-US',
-                               subtitles_mime='text/vtt', subtitle_id=1):
+                   current_time=0, autoplay=True,
+                   stream_type=STREAM_TYPE_BUFFERED,
+                   metadata=None, subtitles=None, subtitles_lang='en-US',
+                   subtitles_mime='text/vtt', subtitle_id=1):
 
         msg = {
             'media': {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -433,7 +433,7 @@ class MediaController(BaseController):
                                  callback_function=lambda response:
                                  self._send_start_play_media(url, content_type,
                                                              title, thumb,
-                                                             current_time
+                                                             current_time,
                                                              autoplay,
                                                              stream_type,
                                                              metadata,

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -440,10 +440,11 @@ class MediaController(BaseController):
                                                   subtitles_mime, subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
-                   current_time=0, autoplay=True,
-                   stream_type=STREAM_TYPE_BUFFERED,
-                   metadata=None, subtitles=None, subtitles_lang='en-US',
-                   subtitles_mime='text/vtt', subtitle_id=1):
+                               current_time=0, autoplay=True,
+                               stream_type=STREAM_TYPE_BUFFERED,
+                               metadata=None, subtitles=None,
+                               subtitles_lang='en-US',
+                               subtitles_mime='text/vtt', subtitle_id=1):
 
         msg = {
             'media': {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -292,10 +292,10 @@ class MediaController(BaseController):
             call listener.new_media_status(status) """
         self._status_listeners.append(listener)
 
-    def update_status(self, blocking=False):
+    def update_status(self, callback_function_param=False):
         """ Send message to update the status. """
         self.send_message({MESSAGE_TYPE: TYPE_GET_STATUS},
-                          wait_for_response=blocking)
+                          callback_function=callback_function_param)
 
     def _send_command(self, command):
         """ Send a command to the Chromecast on media channel. """
@@ -428,7 +428,19 @@ class MediaController(BaseController):
         https://developers.google.com/cast/docs/reference/messages#MediaData
         """
 
-        self._socket_client.receiver_controller.launch_app(self.app_id)
+        self._socket_client.receiver_controller.launch_app(self.app_id,
+                   callback_function=lambda: self._send_start_play_media(url, content_type,
+                                                                         title, thumb,
+                                                                         current_time, autoplay,
+                                                                         stream_type,
+                                                                         metadata, subtitles, subtitles_lang,
+                                                                         subtitles_mime, subtitle_id))
+
+    def _send_start_play_media(self, url, content_type, title=None, thumb=None,
+                   current_time=0, autoplay=True,
+                   stream_type=STREAM_TYPE_BUFFERED,
+                   metadata=None, subtitles=None, subtitles_lang='en-US',
+                   subtitles_mime='text/vtt', subtitle_id=1):
 
         msg = {
             'media': {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -428,19 +428,23 @@ class MediaController(BaseController):
         https://developers.google.com/cast/docs/reference/messages#MediaData
         """
 
-        self._socket_client.receiver_controller.launch_app(self.app_id,
-                   callback_function=lambda: self._send_start_play_media(url, content_type,
-                                                                         title, thumb,
-                                                                         current_time, autoplay,
-                                                                         stream_type,
-                                                                         metadata, subtitles, subtitles_lang,
-                                                                         subtitles_mime, subtitle_id))
+        receiver_ctrl = self._socket_client.receiver_controller
+        receiver_ctrl.launch_app(self.app_id,
+                                 callback_function=lambda response:
+                                 self._send_start_play_media(url, content_type,
+                                                             title, thumb,
+                                                             current_time, autoplay,
+                                                             stream_type,
+                                                             metadata, subtitles,
+                                                             subtitles_lang,
+                                                             subtitles_mime,
+                                                             subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
-                   current_time=0, autoplay=True,
-                   stream_type=STREAM_TYPE_BUFFERED,
-                   metadata=None, subtitles=None, subtitles_lang='en-US',
-                   subtitles_mime='text/vtt', subtitle_id=1):
+                               current_time=0, autoplay=True,
+                               stream_type=STREAM_TYPE_BUFFERED,
+                               metadata=None, subtitles=None, subtitles_lang='en-US',
+                               subtitles_mime='text/vtt', subtitle_id=1):
 
         msg = {
             'media': {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -433,9 +433,11 @@ class MediaController(BaseController):
                                  callback_function=lambda response:
                                  self._send_start_play_media(url, content_type,
                                                              title, thumb,
-                                                             current_time, autoplay,
+                                                             current_time
+                                                             autoplay,
                                                              stream_type,
-                                                             metadata, subtitles,
+                                                             metadata,
+                                                             subtitles,
                                                              subtitles_lang,
                                                              subtitles_mime,
                                                              subtitle_id))
@@ -443,7 +445,8 @@ class MediaController(BaseController):
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
                                current_time=0, autoplay=True,
                                stream_type=STREAM_TYPE_BUFFERED,
-                               metadata=None, subtitles=None, subtitles_lang='en-US',
+                               metadata=None, subtitles=None,
+                               subtitles_lang='en-US',
                                subtitles_mime='text/vtt', subtitle_id=1):
 
         msg = {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -429,12 +429,13 @@ class MediaController(BaseController):
         """
 
         self._socket_client.receiver_controller.launch_app(self.app_id,
-                   callback_function=lambda: self._send_start_play_media(url, content_type,
-                                                                         title, thumb,
-                                                                         current_time, autoplay,
-                                                                         stream_type,
-                                                                         metadata, subtitles, subtitles_lang,
-                                                                         subtitles_mime, subtitle_id))
+                   callback_function=lambda response:
+                     self._send_start_play_media(url, content_type,
+                       title, thumb,
+                       current_time, autoplay,
+                       stream_type,
+                       metadata, subtitles, subtitles_lang,
+                       subtitles_mime, subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
                    current_time=0, autoplay=True,

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -428,14 +428,16 @@ class MediaController(BaseController):
         https://developers.google.com/cast/docs/reference/messages#MediaData
         """
 
-        self._socket_client.receiver_controller.launch_app(self.app_id,
-                   callback_function=lambda response:
-                     self._send_start_play_media(url, content_type,
-                       title, thumb,
-                       current_time, autoplay,
-                       stream_type,
-                       metadata, subtitles, subtitles_lang,
-                       subtitles_mime, subtitle_id))
+        rc = self._socket_client.receiver_controller
+        rc.launch_app(self.app_id,
+                      callback_function=lambda response:
+                      self._send_start_play_media(url, content_type,
+                                                  title, thumb,
+                                                  current_time, autoplay,
+                                                  stream_type,
+                                                  metadata, subtitles,
+                                                  subtitles_lang,
+                                                  subtitles_mime, subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
                    current_time=0, autoplay=True,

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -428,16 +428,17 @@ class MediaController(BaseController):
         https://developers.google.com/cast/docs/reference/messages#MediaData
         """
 
-        rc = self._socket_client.receiver_controller
-        rc.launch_app(self.app_id,
-                      callback_function=lambda response:
-                      self._send_start_play_media(url, content_type,
-                                                  title, thumb,
-                                                  current_time, autoplay,
-                                                  stream_type,
-                                                  metadata, subtitles,
-                                                  subtitles_lang,
-                                                  subtitles_mime, subtitle_id))
+        receiver_ctrl = self._socket_client.receiver_controller
+        receiver_ctrl.launch_app(self.app_id,
+                                 callback_function=lambda response:
+                                 self._send_start_play_media(url, content_type,
+                                                             title, thumb,
+                                                             current_time, autoplay,
+                                                             stream_type,
+                                                             metadata, subtitles,
+                                                             subtitles_lang,
+                                                             subtitles_mime,
+                                                             subtitle_id))
 
     def _send_start_play_media(self, url, content_type, title=None, thumb=None,
                                current_time=0, autoplay=True,

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -35,9 +35,9 @@ class YouTubeController(BaseController):
 
         Only works if there is no video playing.
         """
-        self.launch(lambda: self.start_play(youtube_id))
+        self.launch(lambda reponse: self.start_play(youtube_id))
 
-    def start_play(self,youtube_id):
+    def start_play(self, youtube_id):
         msg = {
             "type": "flingVideo",
             "data": {

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -35,8 +35,9 @@ class YouTubeController(BaseController):
 
         Only works if there is no video playing.
         """
-        self.launch()
+        self.launch(lambda: self.start_play(youtube_id))
 
+    def start_play(self,youtube_id):
         msg = {
             "type": "flingVideo",
             "data": {

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -38,6 +38,9 @@ class YouTubeController(BaseController):
         self.launch(lambda reponse: self.start_play(youtube_id))
 
     def start_play(self, youtube_id):
+        """
+        Sends the play message to the YouTube app.
+        """
         msg = {
             "type": "flingVideo",
             "data": {

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -35,9 +35,9 @@ class YouTubeController(BaseController):
 
         Only works if there is no video playing.
         """
-        self.launch(lambda: self.start_play(youtube_id))
+        self.launch(lambda response: self.start_play(youtube_id))
 
-    def start_play(self,youtube_id):
+    def start_play(self, youtube_id):
         msg = {
             "type": "flingVideo",
             "data": {

--- a/pychromecast/controllers/youtube.py
+++ b/pychromecast/controllers/youtube.py
@@ -35,9 +35,9 @@ class YouTubeController(BaseController):
 
         Only works if there is no video playing.
         """
-        self.launch(lambda response: self.start_play(youtube_id))
+        self.launch(lambda: self.start_play(youtube_id))
 
-    def start_play(self, youtube_id):
+    def start_play(self,youtube_id):
         msg = {
             "type": "flingVideo",
             "data": {

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -407,7 +407,7 @@ class SocketClient(threading.Thread):
         Returns the socket of the connection to use it in you own
         main loop.
         """
-        return self.socket;
+        return self.socket
 
     def _check_connection(self):
         """
@@ -818,8 +818,8 @@ class ReceiverController(BaseController):
 
             self.send_message({MESSAGE_TYPE: TYPE_LAUNCH,
                               APP_ID: app_id},
-                              callback_function=lambda:
-                                                self._block_till_launched(app_id))
+                              callback_function=lambda response:
+                                self._block_till_launched(app_id))
         else:
             self.logger.info(
                 "Not launching app %s - already running", app_id)

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -353,7 +353,7 @@ class SocketClient(threading.Thread):
                 return 0
         except ChromecastConnectionError:
             return 1
-                
+
         # poll the socket
         can_read, _, _ = select.select([self.socket], [], [], self.polltime)
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -752,6 +752,7 @@ class ReceiverController(BaseController):
         self.cast_type = cast_type
         self.blocking = blocking
         self.app_launch_event = threading.Event()
+        self.app_launch_event_function = None
 
         self._status_listeners = []
         self._launch_error_listeners = []
@@ -820,7 +821,7 @@ class ReceiverController(BaseController):
             self.send_message({MESSAGE_TYPE: TYPE_LAUNCH,
                                APP_ID: app_id},
                               callback_function=lambda response:
-                                                self._block_till_launched(app_id))
+                              self._block_till_launched(app_id))
         else:
             self.logger.info(
                 "Not launching app %s - already running", app_id)

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -66,7 +66,7 @@ ERROR_REASON = 'reason'
 
 HB_PING_TIME = 10
 HB_PONG_TIME = 10
-POLL_TIME_BLOCKING = 5
+POLL_TIME_BLOCKING = 5.00
 POLL_TIME_NON_BLOCKING = 0.01
 TIMEOUT_TIME = 30
 RETRY_TIME = 5
@@ -752,6 +752,7 @@ class ReceiverController(BaseController):
         self.cast_type = cast_type
         self.blocking = blocking
         self.app_launch_event = threading.Event()
+        self.app_launch_event_function = None
 
         self._status_listeners = []
         self._launch_error_listeners = []
@@ -817,9 +818,9 @@ class ReceiverController(BaseController):
             self.logger.info("Receiver:Launching app %s", app_id)
 
             self.send_message({MESSAGE_TYPE: TYPE_LAUNCH,
-                              APP_ID: app_id},
+                               APP_ID: app_id},
                               callback_function=lambda response:
-                                self._block_till_launched(app_id))
+                              self._block_till_launched(app_id))
         else:
             self.logger.info(
                 "Not launching app %s - already running", app_id)

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -66,7 +66,7 @@ ERROR_REASON = 'reason'
 
 HB_PING_TIME = 10
 HB_PONG_TIME = 10
-POLL_TIME_BLOCKING = 5
+POLL_TIME_BLOCKING = 5.0
 POLL_TIME_NON_BLOCKING = 0.01
 TIMEOUT_TIME = 30
 RETRY_TIME = 5
@@ -156,12 +156,12 @@ class SocketClient(threading.Thread):
         timeout = kwargs.pop('timeout', None)
         retry_wait = kwargs.pop('retry_wait', None)
         self.blocking = kwargs.pop('blocking', True)
-        
+
         if self.blocking:
             self.polltime = POLL_TIME_BLOCKING
         else:
             self.polltime = POLL_TIME_NON_BLOCKING
-            
+
         super(SocketClient, self).__init__()
 
         self.daemon = True
@@ -407,7 +407,7 @@ class SocketClient(threading.Thread):
         Returns the socket of the connection to use it in you own
         main loop.
         """
-        return self.socket;
+        return self.socket
 
     def _check_connection(self):
         """
@@ -589,7 +589,7 @@ class SocketClient(threading.Thread):
             raise NotConnected("Chromecast is connecting...")
 
         if not no_add_request_id and callback_function:
-            callback = self._request_callbacks[request_id] = {
+            self._request_callbacks[request_id] = {
                 'event': threading.Event(),
                 'response': None,
                 'function': callback_function,
@@ -807,17 +807,18 @@ class ReceiverController(BaseController):
         else:
             self._send_launch_message(app_id, force_launch, callback_function)
 
-    def _send_launch_message(self, app_id, force_launch=False, callback_function=False):
+    def _send_launch_message(self, app_id, force_launch=False,
+                             callback_function=False):
         if force_launch or self.app_id != app_id:
             self.logger.info("Receiver:Launching app %s", app_id)
-            
+
             self.app_to_launch = app_id
             self.app_launch_event.clear()
             self.app_launch_event_function = callback_function
             self.launch_failure = None
 
             self.send_message({MESSAGE_TYPE: TYPE_LAUNCH,
-                              APP_ID: app_id},
+                               APP_ID: app_id},
                               callback_function=lambda response:
                                                 self._block_till_launched(app_id))
         else:

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -589,7 +589,7 @@ class SocketClient(threading.Thread):
             raise NotConnected("Chromecast is connecting...")
 
         if not no_add_request_id and callback_function:
-            callback = self._request_callbacks[request_id] = {
+            self._request_callbacks[request_id] = {
                 'event': threading.Event(),
                 'response': None,
                 'function': callback_function,

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -330,7 +330,6 @@ class SocketClient(threading.Thread):
 
     def run(self):
         """ Start polling the socket. """
-        # pylint: disable=too-many-branches
         self.heartbeat_controller.reset()
         self._force_recon = False
         logging.debug("Thread started...")
@@ -347,12 +346,14 @@ class SocketClient(threading.Thread):
         Use run_once() in your own main loop after you
         receive something on the socket (get_socket()).
         """
+        # pylint: disable=too-many-branches
+
         try:
             if not self._check_connection():
                 return 0
         except ChromecastConnectionError:
             return 1
-
+                
         # poll the socket
         can_read, _, _ = select.select([self.socket], [], [], self.polltime)
 
@@ -365,12 +366,11 @@ class SocketClient(threading.Thread):
                 if self.stop.is_set():
                     self.logger.info(
                         "Stopped while reading message, disconnecting.")
-                    return 1
                 else:
                     self.logger.exception(
                         "Interruption caught without being stopped %s",
                         exc)
-                    return 1
+                return 1
             except ssl.SSLError as exc:
                 if exc.errno == ssl.SSL_ERROR_EOF:
                     if self.stop.is_set():


### PR DESCRIPTION
Hi,

this PR allows the implementation of an own main loop in the application which uses pychromecast as a library.
Just call "run_once()" after you receive data on the socket instead of running a thread which waits for data. Furthermore it makes all calls non-blocking if you use "no_threading=1" argument. The only function which remains blocking is the search function for devices.

Please review my code and give me feedback. I'm sure that it's not perfect yet, but I would like to use this PR to get feedback from you and optimize the code till it can be implemented in the official repository.

Thanks,
Dominik