### PR TITLE
Remove the filters feature from get_chromecasts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,11 @@ How to use
     >> import time
     >> import pychromecast
 
-    >> [cc.device.friendly_name for cc in pychromecast.get_chromecasts()]
+    >> chromecasts = pychromecast.get_chromecasts()
+    >> [cc.device.friendly_name for cc in chromecasts]
     ['Dev', 'Living Room', 'Den', 'Bedroom']
 
-    >> cast = pychromecast.get_chromecast(friendly_name="Living Room")
+    >> cast = next(cc for cc in chromecasts if cc.device.friendly_name == "Living Room")
     >> # Wait for cast device to be ready
     >> cast.wait()
     >> print(cast.device)

--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -16,7 +16,12 @@ import pychromecast.controllers.youtube as youtube
 if '--show-debug' in sys.argv:
     logging.basicConfig(level=logging.DEBUG)
 
-cast = pychromecast.get_chromecast()
+casts = pychromecast.get_chromecasts()
+if len(casts) == 0:
+    print("No Devices Found")
+    exit()
+cast = casts[0]
+
 yt = youtube.YouTubeController()
 cast.register_handler(yt)
 

--- a/examples/non_blocking.py
+++ b/examples/non_blocking.py
@@ -24,8 +24,9 @@ def your_main_loop():
     def callback(chromecast):
         nonlocal cast
         cast = chromecast
+        stop_discovery()
 
-    pychromecast.get_chromecast(blocking=False, callback=callback)
+    stop_discovery = pychromecast.get_chromecasts(blocking=False, callback=callback)
 
     while True:
         if cast:

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -70,8 +70,6 @@ def get_chromecasts(tries=None, retry_wait=None, timeout=None,
     can be defined by passing the retry_wait parameter, the default is
     to wait 5 seconds.
     """
-    logger = logging.getLogger(__name__)
-
     if blocking:
         # Thread blocking chromecast discovery
         hosts = discover_chromecasts()


### PR DESCRIPTION
As discussed in https://github.com/balloob/pychromecast/pull/136, this removes the filters to simplify the `get_chromecasts` implementation.