### PR TITLE
Add media controller wait method

### DIFF
--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -300,13 +300,16 @@ class MediaController(BaseController):
         self.send_message({MESSAGE_TYPE: TYPE_GET_STATUS},
                           callback_function=callback_function_param)
 
-    def _send_command(self, command):
+    def _send_command(self, command, blocking=True, timeout=None):
         """ Send a command to the Chromecast on media channel. """
         if self.status is None or self.status.media_session_id is None:
-            self.logger.warning(
-                "%s command requested but no session is active.",
-                command[MESSAGE_TYPE])
-            return
+            if blocking:
+                self.wait(timeout)
+            else:
+                self.logger.warning(
+                    "%s command requested but no session is active.",
+                    command[MESSAGE_TYPE])
+                return
 
         command['mediaSessionId'] = self.status.media_session_id
 
@@ -347,17 +350,17 @@ class MediaController(BaseController):
 
         return images[0].url if images and len(images) > 0 else None
 
-    def play(self):
+    def play(self, blocking=True, timeout=None):
         """ Send the PLAY command. """
-        self._send_command({MESSAGE_TYPE: TYPE_PLAY})
+        self._send_command({MESSAGE_TYPE: TYPE_PLAY}, blocking, timeout)
 
-    def pause(self):
+    def pause(self, blocking=True, timeout=None):
         """ Send the PAUSE command. """
-        self._send_command({MESSAGE_TYPE: TYPE_PAUSE})
+        self._send_command({MESSAGE_TYPE: TYPE_PAUSE}, blocking, timeout)
 
-    def stop(self):
+    def stop(self, blocking=True, timeout=None):
         """ Send the STOP command. """
-        self._send_command({MESSAGE_TYPE: TYPE_STOP})
+        self._send_command({MESSAGE_TYPE: TYPE_STOP}, blocking, timeout)
 
     def rewind(self):
         """ Starts playing the media from the beginning. """
@@ -367,25 +370,30 @@ class MediaController(BaseController):
         """ Skips rest of the media. Values less then -5 behaved flaky. """
         self.seek(int(self.status.duration)-5)
 
-    def seek(self, position):
+    def seek(self, position, blocking=True, timeout=None):
         """ Seek the media to a specific location. """
-        self._send_command({MESSAGE_TYPE: TYPE_SEEK,
-                            "currentTime": position,
-                            "resumeState": "PLAYBACK_START"})
+        self._send_command(
+            {MESSAGE_TYPE: TYPE_SEEK,
+             "currentTime": position,
+             "resumeState": "PLAYBACK_START"},
+            blocking, timeout
+        )
 
-    def enable_subtitle(self, track_id):
+    def enable_subtitle(self, track_id, blocking=True, timeout=None):
         """ Enable specific text track. """
-        self._send_command({
-            MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
-            "activeTrackIds": [track_id]
-        })
+        self._send_command(
+            {MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
+             "activeTrackIds": [track_id]},
+            blocking, timeout
+        )
 
-    def disable_subtitle(self):
+    def disable_subtitle(self, blocking=True, timeout=None):
         """ Disable subtitle. """
-        self._send_command({
-            MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
-            "activeTrackIds": []
-        })
+        self._send_command(
+            {MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
+             "activeTrackIds": []},
+            blocking, timeout
+        )
 
     def wait(self, timeout=None):
         """

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -300,16 +300,13 @@ class MediaController(BaseController):
         self.send_message({MESSAGE_TYPE: TYPE_GET_STATUS},
                           callback_function=callback_function_param)
 
-    def _send_command(self, command, blocking=True, timeout=None):
+    def _send_command(self, command):
         """ Send a command to the Chromecast on media channel. """
         if self.status is None or self.status.media_session_id is None:
-            if blocking:
-                self.wait(timeout)
-            else:
-                self.logger.warning(
-                    "%s command requested but no session is active.",
-                    command[MESSAGE_TYPE])
-                return
+            self.logger.warning(
+                "%s command requested but no session is active.",
+                command[MESSAGE_TYPE])
+            return
 
         command['mediaSessionId'] = self.status.media_session_id
 
@@ -350,17 +347,17 @@ class MediaController(BaseController):
 
         return images[0].url if images and len(images) > 0 else None
 
-    def play(self, blocking=True, timeout=None):
+    def play(self):
         """ Send the PLAY command. """
-        self._send_command({MESSAGE_TYPE: TYPE_PLAY}, blocking, timeout)
+        self._send_command({MESSAGE_TYPE: TYPE_PLAY})
 
-    def pause(self, blocking=True, timeout=None):
+    def pause(self):
         """ Send the PAUSE command. """
-        self._send_command({MESSAGE_TYPE: TYPE_PAUSE}, blocking, timeout)
+        self._send_command({MESSAGE_TYPE: TYPE_PAUSE})
 
-    def stop(self, blocking=True, timeout=None):
+    def stop(self):
         """ Send the STOP command. """
-        self._send_command({MESSAGE_TYPE: TYPE_STOP}, blocking, timeout)
+        self._send_command({MESSAGE_TYPE: TYPE_STOP})
 
     def rewind(self):
         """ Starts playing the media from the beginning. """
@@ -370,30 +367,25 @@ class MediaController(BaseController):
         """ Skips rest of the media. Values less then -5 behaved flaky. """
         self.seek(int(self.status.duration)-5)
 
-    def seek(self, position, blocking=True, timeout=None):
+    def seek(self, position):
         """ Seek the media to a specific location. """
-        self._send_command(
-            {MESSAGE_TYPE: TYPE_SEEK,
-             "currentTime": position,
-             "resumeState": "PLAYBACK_START"},
-            blocking, timeout
-        )
+        self._send_command({MESSAGE_TYPE: TYPE_SEEK,
+                            "currentTime": position,
+                            "resumeState": "PLAYBACK_START"})
 
-    def enable_subtitle(self, track_id, blocking=True, timeout=None):
+    def enable_subtitle(self, track_id):
         """ Enable specific text track. """
-        self._send_command(
-            {MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
-             "activeTrackIds": [track_id]},
-            blocking, timeout
-        )
+        self._send_command({
+            MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
+            "activeTrackIds": [track_id]
+        })
 
-    def disable_subtitle(self, blocking=True, timeout=None):
+    def disable_subtitle(self):
         """ Disable subtitle. """
-        self._send_command(
-            {MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
-             "activeTrackIds": []},
-            blocking, timeout
-        )
+        self._send_command({
+            MESSAGE_TYPE: TYPE_EDIT_TRACKS_INFO,
+            "activeTrackIds": []
+        })
 
     def wait(self, timeout=None):
         """

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -387,10 +387,11 @@ class MediaController(BaseController):
             "activeTrackIds": []
         })
 
-    def wait(self, timeout=None):
+    def block_until_status_received(self, timeout=None):
         """
-        Waits until the media status has been updated at least once. The
-        controller is ready as soon a status message has been received.
+        Blocks thread until the media status has been updated at least once.
+        The media controller only accepts playback controll commands after a
+        status message has been received.
 
         If the status has already been received then the method returns
         immediately.


### PR DESCRIPTION
This PR adds a wait method to the media controller. This is convenient since commands to the media controller aren't allowed until the status has been received.

Fixes #128  