### PR TITLE
Include block_until_active in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ How to use
 
     >> mc = cast.media_controller
     >> mc.play_media('http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4', 'video/mp4')
+    >> mc.block_until_active()
     >> print(mc.status)
     MediaStatus(current_time=42.458322, content_id=u'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4', content_type=u'video/mp4', duration=596.474195, stream_type=u'BUFFERED', idle_reason=None, media_session_id=1, playback_rate=1, player_state=u'PLAYING', supported_media_commands=15, volume_level=1, volume_muted=False)
 


### PR DESCRIPTION
This ensures that `mc.pause()` isn't called until the media session is active. Fixes #151.