### PR TITLE
Let pychromecast work on non-standard device.

### DIFF
--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -53,6 +53,7 @@ class CastListener(object):
             return value.decode('utf-8')
 
         ips = zconf.cache.entries_with_name(service.server.lower())
+        ips = [ip for ip in ips if len(ip.address) == 4]
         host = repr(ips[0]) if ips else service.server
 
         model_name = get_value('md')

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -60,7 +60,10 @@ class CastListener(object):
         friendly_name = get_value('fn')
 
         if uuid:
-            uuid = UUID(uuid)
+            try:
+                uuid = UUID(uuid)
+            except ValueError:
+                pass
 
         self.services[name] = (host, service.port, uuid, model_name,
                                friendly_name)


### PR DESCRIPTION
- Handler non-standard format uuid.
- Remove the ipv6 address in discovery processing.

Because Pyzeroconf cannot handle the __repr__ method for ipv6 address in class DNSAddress.
The pychromecast discovery would failed when cast device with ipv6 address, such as the follow dns data. 

```
;; QUESTION SECTION:
;_googlecast._tcp.local.		IN	PTR

;; ANSWER SECTION:
_googlecast._tcp.local.	10	IN	PTR	XXXX._googlecast._tcp.local.

;; ADDITIONAL SECTION:
XXXX._googlecast._tcp.local. 10 IN SRV 0 0 8009 XXXX.local.
XXXX._googlecast._tcp.local. 10 IN TXT "id=F45C89B6CD2D" "ve=04" "md=Reflector 2" "ic=/setup/icon.png" "fn=XXXX" "ca=5" "st=0" "rmodel=MacBookPro10,1" "rrv=1.01"
XXXX.local. 10	IN	AAAA	fe80::fb:1146:1b32:fe8b
XXXX.local. 10	IN	A	192.168.1.115
XXXX.local. 10	IN	AAAA	fd3c:9aee:a63d::cf8:d9ee:d0fa:8202
```