### PR TITLE
Fix bug in ReceiverController._send_launch_message

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -826,7 +826,8 @@ class ReceiverController(BaseController):
         else:
             self.logger.info(
                 "Not launching app %s - already running", app_id)
-            callback_function()
+            if callback_function:
+                callback_function()
 
     def _block_till_launched(self, app_id):
         if self.blocking:


### PR DESCRIPTION
Hi. When starting the same cc-app twice in a row, I came across this:
```
In [3]: cast.start_app('CC1AD845')

In [4]: cast.start_app('CC1AD845')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-4c3499fc5ffa> in <module>()
----> 1 cast.start_app('CC1AD845')

/home/benno/python/chromecast/lib/python3.5/site-packages/pychromecast/__init__.py in start_app(self, app_id)
    265         self.logger.info("Starting app %s", app_id)
    266 
--> 267         self.socket_client.receiver_controller.launch_app(app_id)
    268 
    269     def quit_app(self):

/home/benno/python/chromecast/lib/python3.5/site-packages/pychromecast/socket_client.py in launch_app(self, app_id, force_launch, callback_function)
    807                                                          callback_function))
    808         else:
--> 809             self._send_launch_message(app_id, force_launch, callback_function)
    810 
    811     def _send_launch_message(self, app_id, force_launch=False,

/home/benno/python/chromecast/lib/python3.5/site-packages/pychromecast/socket_client.py in _send_launch_message(self, app_id, force_launch, callback_function)
    826             self.logger.info(
    827                 "Not launching app %s - already running", app_id)
--> 828             callback_function()
    829 
    830     def _block_till_launched(self, app_id):

TypeError: 'bool' object is not callable
```
It would seem that if `_send_launch_message` is called without `force_launch` and `callback_function` being set, `callback_function()` is called regardless, when the supplied app-id matches the id of the app already running.
I'm not sure if my fix is correct, as I do not fully understand how the code works, but it stops `pychromecast` from crashing in this scenario.