### PR TITLE
Fix link markup in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,9 @@ currently supports:
 -  Easily extendable to add support for unsupported namespaces
 -  Multi-room setups with Audio cast devices
 
-*Check out [Home Assistant](https://home-assistant.io) for a ready-made solution using PyChromecast for controlling and automating your Chromecast or Cast-enabled device like Google Home.*
+*Check out* `Home Assistant <https://home-assistant.io>`_ *for a
+ready-made solution using PyChromecast for controlling and automating
+your Chromecast or Cast-enabled device like Google Home.*
 
 Dependencies
 ------------


### PR DESCRIPTION
Was originally using markdown syntax.

Surprisingly, rst doesn't allow nested markup, which is why there are two emphasis blocks

http://docutils.sourceforge.net/FAQ.html#is-nested-inline-markup-possible