### PR TITLE
catch OSError as well as socket.error

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -255,7 +255,9 @@ class SocketClient(threading.Thread):
 
                 self.logger.debug("Connected!")
                 break
-            except socket.error as err:
+            # socket.error is a deprecated alias of OSError in Python 3.3+,
+            # can be removed when Python 2.x support is dropped
+            except (OSError, socket.error) as err:
                 self.connecting = True
                 if self.stop.is_set():
                     self.logger.error(


### PR DESCRIPTION
Python 3.3+ restructured the exception hierarchy so that all socket
errors children of `OSError`.

In earlier versions of Python, `socket.error` inherited from IOError,
which does not inherit from OSError. So if an OSError exception was
raised, it would not be caught.

example: https://github.com/erik/lastcast/issues/31
see also: https://www.python.org/dev/peps/pep-3151/