### PR TITLE
Fix CAST_TYPES mapping

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -22,7 +22,9 @@ CAST_TYPE_GROUP = 'group'
 
 CAST_TYPES = {
     u'chromecast': CAST_TYPE_CHROMECAST,
+    u'eureka dongle': CAST_TYPE_CHROMECAST,
     u'chromecast audio': CAST_TYPE_AUDIO,
+    u'google home': CAST_TYPE_AUDIO,
     u'google cast group': CAST_TYPE_GROUP,
 }
 


### PR DESCRIPTION
Fixes #201 which incorrectly caused google home devices to be assumed to be video+audio cast types by adding new 'google home' and 'eureka dongle' mappings.