### PR TITLE
Don't sleep when there are no tries remaining

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -276,8 +276,9 @@ class SocketClient(threading.Thread):
                     retry_log_fun = self.logger.debug
 
                     time.sleep(self.retry_wait)
-                    tries -= 1
 
+                if tries:
+                    tries -= 1
         else:
             self.stop.set()
             self.logger.error("Failed to connect. No retries.")

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -277,7 +277,7 @@ class SocketClient(threading.Thread):
 
                     time.sleep(self.retry_wait)
                     tries -= 1
-                
+
         else:
             self.stop.set()
             self.logger.error("Failed to connect. No retries.")

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -268,13 +268,16 @@ class SocketClient(threading.Thread):
                 self._report_connection_status(
                     ConnectionStatus(CONNECTION_STATUS_FAILED,
                                      NetworkAddress(self.host, self.port)))
-                retry_log_fun("Failed to connect, retrying in %.1fs",
-                              self.retry_wait)
-                retry_log_fun = self.logger.debug
 
-                time.sleep(self.retry_wait)
-                if tries:
+                # Only sleep if we have another retry remaining
+                if tries and tries > 1:
+                    retry_log_fun("Failed to connect, retrying in %.1fs",
+                                  self.retry_wait)
+                    retry_log_fun = self.logger.debug
+
+                    time.sleep(self.retry_wait)
                     tries -= 1
+                
         else:
             self.stop.set()
             self.logger.error("Failed to connect. No retries.")


### PR DESCRIPTION
Fixes simple logic flow error where the thread would sleep
regardless of there being a remaining retry or not.