### PR TITLE
Add return for "uri" value, fix SSL issues on Windows

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -218,6 +218,11 @@ class Chromecast(object):
         """
         return self.device.friendly_name
 
+    """Returns device URI"""
+    @property
+    def uri(self):
+        string = str(self.host) + ":" + str(self.port)
+        return string
     @property
     def model_name(self):
         """ Returns the model name of the Chromecast device. """
@@ -346,6 +351,6 @@ class Chromecast(object):
         return txt
 
     def __unicode__(self):
-        return u"Chromecast({}, {}, {}, {}, {})".format(
+        return u"Chromecast({}, {}, {}, {}, {}, {})".format(
             self.host, self.port, self.device.friendly_name,
-            self.device.model_name, self.device.manufacturer)
+            self.device.model_name, self.device.manufacturer, self.uri)

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -221,7 +221,7 @@ class Chromecast(object):
     @property
     def uri(self):
         """ Returns the device URI (ip:port) """
-        return str(self.host) + ":" + str(self.port)
+        return "{}:{}".format(self.host, self.port)
 
     @property
     def model_name(self):

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -218,11 +218,11 @@ class Chromecast(object):
         """
         return self.device.friendly_name
 
-    """Returns device URI"""
     @property
     def uri(self):
-        string = str(self.host) + ":" + str(self.port)
-        return string
+        """ Returns the device URI (ip:port) """
+        return str(self.host) + ":" + str(self.port)
+
     @property
     def model_name(self):
         """ Returns the model name of the Chromecast device. """
@@ -351,6 +351,6 @@ class Chromecast(object):
         return txt
 
     def __unicode__(self):
-        return u"Chromecast({}, {}, {}, {}, {}, {})".format(
+        return u"Chromecast({}, {}, {}, {}, {})".format(
             self.host, self.port, self.device.friendly_name,
-            self.device.model_name, self.device.manufacturer, self.uri)
+            self.device.model_name, self.device.manufacturer)

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -238,12 +238,14 @@ class SocketClient(threading.Thread):
 
         while not self.stop.is_set() and (tries is None or tries > 0):
             try:
-                self.socket = ssl.wrap_socket(socket.socket())
+                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.settimeout(self.timeout)
+                self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 self._report_connection_status(
                     ConnectionStatus(CONNECTION_STATUS_CONNECTING,
                                      NetworkAddress(self.host, self.port)))
                 self.socket.connect((self.host, self.port))
+                self.socket = ssl.wrap_socket(self.socket)
                 self.connecting = False
                 self._force_recon = False
                 self._report_connection_status(


### PR DESCRIPTION
This adds a return value for URI, which can be used later to address the device directly in the event there are two devices with the same friendlyname (SHIELD).

Also, on Windows, as I noted in my issue earlier, there is a problem with the wrap_ssl call and socket creation which appears to only manifest in certain places, but is still a big problem nonetheless. 

By dictating that the socket is reusable and wrapping the ssl after connecting, we can avoid getting errno10060 and 10057. If you look at HomeAssistant's issue tracker, you'll see several different complaints of massive connection issues in the logs.

I've tested this under Synology Linux, works great. However, there may be an issue for BSD users where you will also need to add SO_REUSEPORT - but this option can't be set all the time in python, less it throws an error. So, you have to check for the option and catch an error, and if no error is thrown, then set it. 

Maybe. I'm not sure if it's necessary in this case, this would need to be tested under BSD and verified first for full compatibility.