### PR TITLE
Fixes for discovery, FreeBSD Socket creation

### DIFF
--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -9,6 +9,7 @@ DISCOVER_TIMEOUT = 5
 
 class CastListener(object):
     """Zeroconf Cast Services collection."""
+
     def __init__(self, callback=None):
         self.services = {}
         self.callback = callback
@@ -84,8 +85,13 @@ def start_discovery(callback=None):
     ServiceBrowser object.
     """
     listener = CastListener(callback)
-    return listener, \
-        ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
+    sb = False
+    try:
+        sb = ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
+    except Exception:
+        return listener, False
+    finally:
+        return listener, sb
 
 
 def stop_discovery(browser):
@@ -96,6 +102,7 @@ def stop_discovery(browser):
 def discover_chromecasts(max_devices=None, timeout=DISCOVER_TIMEOUT):
     """ Discover chromecasts on the network. """
     from threading import Event
+    browser = False
     try:
         # pylint: disable=unused-argument
         def callback(name):
@@ -110,5 +117,8 @@ def discover_chromecasts(max_devices=None, timeout=DISCOVER_TIMEOUT):
         discover_complete.wait(timeout)
 
         return listener.devices
+    except Exception:
+        return
     finally:
-        stop_discovery(browser)
+        if browser is not False:
+            stop_discovery(browser)

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -101,7 +101,6 @@ def start_discovery(callback=None):
     return listener, service_browser
 
 
-
 def stop_discovery(browser):
     """Stop the chromecast discovery thread."""
     browser.zc.close()

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -86,13 +86,17 @@ def start_discovery(callback=None):
     ServiceBrowser object.
     """
     listener = CastListener(callback)
-    sb = False
+    service_browser = False
     try:
-        sb = ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
-    except (BadTypeInNameException, NotImplementedError, OSError, socket.error, NonUniqueNameException):
-        sb = False
+        service_browser = ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
+    except (BadTypeInNameException,
+            NotImplementedError,
+            OSError,
+            socket.error,
+            NonUniqueNameException):
+        service_browser = False
     finally:
-        return listener, sb
+        return listener, service_browser
 
 
 def stop_discovery(browser):
@@ -118,8 +122,8 @@ def discover_chromecasts(max_devices=None, timeout=DISCOVER_TIMEOUT):
         discover_complete.wait(timeout)
 
         return listener.devices
-    except Exception:
-        return
+    except Exception:  # pylint: disable=broad-except
+        raise
     finally:
         if browser is not False:
             stop_discovery(browser)

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -3,7 +3,7 @@ import socket
 from uuid import UUID
 
 import six
-from zeroconf import ServiceBrowser, Zeroconf, BadTypeInNameException, NonUniqueNameException
+import zeroconf
 
 DISCOVER_TIMEOUT = 5
 
@@ -88,13 +88,16 @@ def start_discovery(callback=None):
     listener = CastListener(callback)
     service_browser = False
     try:
-        service_browser = ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
-    except (BadTypeInNameException,
+        service_browser = zeroconf.ServiceBrowser(zeroconf.Zeroconf(),
+                                                  "_googlecast._tcp.local.",
+                                                  listener)
+    except (zeroconf.BadTypeInNameException,
             NotImplementedError,
             OSError,
             socket.error,
-            NonUniqueNameException):
+            zeroconf.NonUniqueNameException):
         service_browser = False
+        pass
     finally:
         return listener, service_browser
 

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -96,10 +96,10 @@ def start_discovery(callback=None):
             OSError,
             socket.error,
             zeroconf.NonUniqueNameException):
-        service_browser = False
         pass
-    finally:
-        return listener, service_browser
+
+    return listener, service_browser
+
 
 
 def stop_discovery(browser):

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -88,8 +88,8 @@ def start_discovery(callback=None):
     sb = False
     try:
         sb = ServiceBrowser(Zeroconf(), "_googlecast._tcp.local.", listener)
-    except Exception:
-        return listener, False
+    except (BadTypeInNameException, NotImplementedError, OSError, socket.error, NonUniqueNameException):
+        sb = False
     finally:
         return listener, sb
 

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -1,8 +1,9 @@
 """Discovers Chromecasts on the network using mDNS/zeroconf."""
+import socket
 from uuid import UUID
 
 import six
-from zeroconf import ServiceBrowser, Zeroconf
+from zeroconf import ServiceBrowser, Zeroconf, BadTypeInNameException, NonUniqueNameException
 
 DISCOVER_TIMEOUT = 5
 

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -975,19 +975,20 @@ def new_socket():
     Try to set SO_REUSEPORT for BSD-flavored systems if it's an option.
     Catches errors if not.
     """
-    new_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    new_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    new_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    new_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
     try:
+        # noinspection PyUnresolvedReferences
         reuseport = socket.SO_REUSEPORT
     except AttributeError:
         pass
     else:
         try:
-            new_socket.setsockopt(socket.SOL_SOCKET, reuseport, 1)
+            new_sock.setsockopt(socket.SOL_SOCKET, reuseport, 1)
         except (OSError, socket.error) as err:
             # OSError on python 3, socket.error on python 2
-            if not err.errno == errno.ENOPROTOOPT:
+            if err.errno != errno.ENOPROTOOPT:
                 raise
 
-    return new_socket
+    return new_sock


### PR DESCRIPTION
Fix issues in discovery where things blow up if browser is not able to be created because of networking issues.

Add proper checks in socket_client for BSD-derived operating systems, bind sockets accordingly...

Lint