### PR TITLE
Fix Channel Close

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -240,7 +240,8 @@ class SocketClient(threading.Thread):
             try:
                 self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.socket.settimeout(self.timeout)
-                self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR,
+                                       1)
                 self._report_connection_status(
                     ConnectionStatus(CONNECTION_STATUS_CONNECTING,
                                      NetworkAddress(self.host, self.port)))


### PR DESCRIPTION
**TL;DR** We're closing channels incorrectly.

## Description

When we receive a `{"type": "CLOSE"}` message, the cast device expects us to acknowledge the channel close by sending a `{"type": "CLOSE"}` ourselves. Currently, we're only notifying all of the socket_client's handlers about the close message, that's incorrect.

## How to replicate

Thanks to @benjamin1492, who provided detailed logs, I've been able to replicate this issue reliably (still it was an immense amount of time looking through logs, especially when seeing how easy the fix is 😩).

So to replicate, I used Home Assistant (sorry for all non-Home Assistant users, it's just much easier to replicate with an UI) and a Google Home Mini. First, start up Home Assistant and let it discover/manually add the cast device. Next, just send a bunch of commands such as setting the volume. Then unplug the device and send a bunch of commands to make the socket client go into a failed state. Finally, reconnect the device and, once again, do a bunch of commands.

The previous version would have now errored out and we'd receive a `CLOSE` message for every message we send.

With this PR, the `CLOSE` is correctly handled by acknowledging it and automatically setting up a new channel. Thus, we can control chromecasts even after a reconnect/group leader change.

(I'm going to go celebrate now 🎉; this took waaay too long)
