### PR TITLE
Add adjusted_current_time() function

### DIFF
--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -76,7 +76,7 @@ class MediaStatus(object):
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
             # Add time since last update
             return (self.current_time +
-                    datetime.utcnow() - self.last_updated).total_seconds()
+                    (datetime.utcnow() - self.last_updated)).total_seconds()
         # Not playing, return last reported seek time
         return self.current_time
 

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -71,8 +71,9 @@ class MediaStatus(object):
         self.current_subtitle_tracks = []
         self.last_updated = None
 
-    def get_seek_time(self):
-        """ Returns current seek time of media in seconds """
+    @property
+    def adjusted_current_time(self):
+        """ Returns calculated current seek time of media in seconds """
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
             # Add time since last update
             return (self.current_time +

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -76,7 +76,7 @@ class MediaStatus(object):
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
             # Add time since last update
             return (self.current_time +
-                (datetime.utcnow()-self.last_updated).total_seconds())
+                    datetime.utcnow() - self.last_updated).total_seconds()
         # Not playing, return last reported seek time
         return self.current_time
 

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -73,8 +73,7 @@ class MediaStatus(object):
 
     def get_current_time(self):
         """ Get current seek time of video (does not account for buffering time) """
-        if :
-            return (self.current_time + (time.time()-self.last_updated)) if self.player_state == MEDIA_PLAYER_STATE_PLAYING else self.current_time
+        return (self.current_time + (time.time()-self.last_updated)) if self.player_state == MEDIA_PLAYER_STATE_PLAYING else self.current_time
 
     @property
     def metadata_type(self):

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -72,7 +72,7 @@ class MediaStatus(object):
         self.last_updated = time.time()
 
     def get_current_time(self):
-        """ Get current seek time of video (does not account for buffering time) """
+        """ Get current seek time of video """
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
             current_time = self.current_time + (time.time()-self.last_updated)
         else:

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -2,7 +2,7 @@
 Provides a controller for controlling the default media players
 on the Chromecast.
 """
-import time
+import datetime
 
 from collections import namedtuple
 import threading
@@ -69,15 +69,15 @@ class MediaStatus(object):
         self.media_metadata = {}
         self.subtitle_tracks = {}
         self.current_subtitle_tracks = []
-        self.last_updated = time.time()
+        self.last_updated = None
 
-    def get_current_time(self):
-        """ Get current seek time of video """
+    def get_seek_time(self):
+        """ Returns current seek time of media in seconds """
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
-            current_time = self.current_time + (time.time()-self.last_updated)
-        else:
-            current_time = self.current_time
-        return current_time
+            # Add time since last update
+            return self.current_time + (datetime.utcnow()-self.last_updated).total_seconds()
+        # Not playing, return last reported seek time
+        return self.current_time
 
     @property
     def metadata_type(self):
@@ -243,7 +243,7 @@ class MediaStatus(object):
         self.subtitle_tracks = media_data.get('tracks', self.subtitle_tracks)
         self.current_subtitle_tracks = status_data.get(
             'activeTrackIds', self.current_subtitle_tracks)
-        self.last_updated = time.time()
+        self.last_updated = datetime.utcnow()
 
     def __repr__(self):
         info = {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -75,7 +75,8 @@ class MediaStatus(object):
         """ Returns current seek time of media in seconds """
         if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
             # Add time since last update
-            return self.current_time + (datetime.utcnow()-self.last_updated).total_seconds()
+            return (self.current_time +
+                (datetime.utcnow()-self.last_updated).total_seconds())
         # Not playing, return last reported seek time
         return self.current_time
 

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -67,6 +67,7 @@ class MediaStatus(object):
         self.media_metadata = {}
         self.subtitle_tracks = {}
         self.current_subtitle_tracks = []
+        self.last_updated = now()
 
     @property
     def metadata_type(self):
@@ -232,6 +233,7 @@ class MediaStatus(object):
         self.subtitle_tracks = media_data.get('tracks', self.subtitle_tracks)
         self.current_subtitle_tracks = status_data.get(
             'activeTrackIds', self.current_subtitle_tracks)
+        self.last_updated = now()
 
     def __repr__(self):
         info = {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -2,7 +2,7 @@
 Provides a controller for controlling the default media players
 on the Chromecast.
 """
-import datetime
+from datetime import datetime
 
 from collections import namedtuple
 import threading

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -73,7 +73,11 @@ class MediaStatus(object):
 
     def get_current_time(self):
         """ Get current seek time of video (does not account for buffering time) """
-        return (self.current_time + (time.time()-self.last_updated)) if self.player_state == MEDIA_PLAYER_STATE_PLAYING else self.current_time
+        if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
+            current_time = self.current_time + (time.time()-self.last_updated)
+        else:
+            current_time = self.current_time
+        return current_time
 
     @property
     def metadata_type(self):

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -2,6 +2,8 @@
 Provides a controller for controlling the default media players
 on the Chromecast.
 """
+import time
+
 from collections import namedtuple
 import threading
 
@@ -67,7 +69,14 @@ class MediaStatus(object):
         self.media_metadata = {}
         self.subtitle_tracks = {}
         self.current_subtitle_tracks = []
-        self.last_updated = now()
+        self.last_updated = time.time()
+
+    def get_current_time(self):
+        """ Get current seek time of video (does not account for buffering time) """
+        if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
+            return (self.current_time + (time.time()-self.last_updated))
+        else:
+            return (self.current_time)
 
     @property
     def metadata_type(self):
@@ -233,7 +242,7 @@ class MediaStatus(object):
         self.subtitle_tracks = media_data.get('tracks', self.subtitle_tracks)
         self.current_subtitle_tracks = status_data.get(
             'activeTrackIds', self.current_subtitle_tracks)
-        self.last_updated = now()
+        self.last_updated = time.time()
 
     def __repr__(self):
         info = {

--- a/pychromecast/controllers/media.py
+++ b/pychromecast/controllers/media.py
@@ -73,10 +73,8 @@ class MediaStatus(object):
 
     def get_current_time(self):
         """ Get current seek time of video (does not account for buffering time) """
-        if self.player_state == MEDIA_PLAYER_STATE_PLAYING:
-            return (self.current_time + (time.time()-self.last_updated))
-        else:
-            return (self.current_time)
+        if :
+            return (self.current_time + (time.time()-self.last_updated)) if self.player_state == MEDIA_PLAYER_STATE_PLAYING else self.current_time
 
     @property
     def metadata_type(self):


### PR DESCRIPTION
This pull request adds a timestamp (`last_updated`) to the `MediaStatus` class. This attribute is used in the method `MediaStatus.adjusted_current_time()` which returns the approximate current seek time.

It is unknown whether buffering would cause this to return an inaccurate seek time. I am not able to test this because I am fortunate enough to have fast internet! From what it seems, however, since the `MediaStatus` would be updated each time buffering or playing occurs, it should work just fine.