### PR TITLE
Fix not waiting with no tries set

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -267,7 +267,7 @@ class SocketClient(threading.Thread):
                                      NetworkAddress(self.host, self.port)))
 
                 # Only sleep if we have another retry remaining
-                if (tries and tries > 1) or not tries:
+                if tries is None or tries > 1:
                     retry_log_fun("Failed to connect, retrying in %.1fs",
                                   self.retry_wait)
                     retry_log_fun = self.logger.debug

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -267,11 +267,10 @@ class SocketClient(threading.Thread):
                                      NetworkAddress(self.host, self.port)))
 
                 # Only sleep if we have another retry remaining
-                if tries and tries > 1:
+                if (tries and tries > 1) or not tries:
                     retry_log_fun("Failed to connect, retrying in %.1fs",
                                   self.retry_wait)
                     retry_log_fun = self.logger.debug
-
                     time.sleep(self.retry_wait)
 
                 if tries:


### PR DESCRIPTION
We're not waiting when `tries` is `None` but `retry_wait` is set. This can cause a flood of requests if no connection can be made.

Probably related https://github.com/home-assistant/home-assistant/issues/13319

(I've been using this patch for a while now and apparently forgot to put it in a PR)