### PR TITLE
Spotify controller creation

### DIFF
--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -1,0 +1,14 @@
+import pychromecast
+from pychromecast.controllers.spotify import SpotifyController
+
+chromecasts = pychromecast.get_chromecasts()
+cast = chromecasts[0]
+
+CAST_NAME = "My Chromecast"
+
+if cast.name == CAST_NAME:
+    sp = SpotifyController(CAST_NAME,"SPOTIFY_USERNAME","SPOTIFY_PASSWORD")
+    cast.register_handler(sp)
+    sp.launch_app()
+
+    sp.play_song("spotify:track:3Zwu2K0Qa5sT6teCCHPShP")

--- a/pychromecast/config.py
+++ b/pychromecast/config.py
@@ -10,6 +10,7 @@ APP_YOUTUBE = "YouTube"
 APP_MEDIA_RECEIVER = "CC1AD845"
 APP_PLEX = "06ee44ee-e7e3-4249-83b6-f5d0b6f07f34_1"
 APP_DASHCAST = "84912283"
+APP_SPOTIFY = "CC32E753"
 
 
 def get_possible_app_ids():

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -1,22 +1,96 @@
-from pychromecast.controllers import BaseController
 import logging
+import os
+import requests
+
+from pychromecast.controllers import BaseController
+from ..config import APP_SPOTIFY
 
 logging.basicConfig(level=logging.DEBUG)
 
+APP_NAMESPACE = "urn:x-cast:com.spotify.chromecast.secure.v1"
+USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
+
+TYPE_STATUS = "setCredentials"
+
 
 class SpotifyController(BaseController):
-    def __init__(self):
+    def __init__(self, username, password, friendly_name):
         super(SpotifyController, self).__init__(
-            "urn:x-cast:com.spotify.chromecast.secure.v1", "CC32E753")
+              APP_NAMESPACE, APP_SPOTIFY)
+
+        self.logger = logging.getLogger(__name__)
+        self.username = username
+        self.password = password
+        self.session_started = False
+        self.token = None
+        self.expiration_date = None
 
     def receive_message(self, message, data):
-        print("Cast message: {}".format(data))
+        self.logger.debug("Cast message: {}".format(data))
+        
+        return True
 
-        return True  # indicate you handled this message
+    def _get_csrf(self, session, cookies):
+        headers = {'user-agent': USER_AGENT}
 
-    def start_playback(self, credentials):
+        response = session.get("https://accounts.spotify.com/login",
+                               headers=headers, cookies=cookies)
+        response.raise_for_status()
+
+        return response.cookies['csrf_token']
+
+    def _login(self, session, cookies, username, password, csrf_token):
+        headers = {'user-agent': USER_AGENT}
+
+        data = {"remember": False, "username": username, "password": password,
+                "csrf_token": csrf_token}
+
+        response = session.post("https://accounts.spotify.com/api/login",
+                                data=data, cookies=cookies, headers=headers)
+
+        response.raise_for_status()
+
+    def _get_access_token(self, session, cookies):
+        headers = {'user-agent': USER_AGENT}
+
+        response = session.get("https://open.spotify.com/browse",
+                               headers=headers, cookies=cookies)
+        response.raise_for_status()
+
+        self.token = response.cookies['wp_access_token']
+
+        expiration = response.cookies['wp_expiration']
+        self.expiration_date = int(expiration)//1000
+
+        # return response.cookies['wp_access_token']
+
+    def start_session(self):
+        # arbitrary value and can be static
+        cookies = {"__bon": "MHwwfC01ODc4MjExMzJ8LTI0Njg4NDg3NTQ0fDF8MXwxfDE="}
+
+        if self.username is None:
+            username = os.getenv("SPOTIFY_USERNAME")
+
+        if self.password is None:
+            password = os.getenv("SPOTIFY_PASS")
+
+        if self.username is None or self.password is None:
+            raise("No username or password")
+
+        session = requests.Session()
+        token = self. _get_csrf(session, cookies)
+
+        self._login(session, cookies, self.username, self.password, token)
+        self._get_access_token(session, cookies)
+
+        self.session_started = True
+
+        return self.token
+
+    def launch_app(self):
 
         def callback():
-            self.send_message({"type":"setCredentials","credentials":credentials},inc_session_id=True)
+            self.send_message({"type": TYPE_STATUS, "credentials": self.token})
 
+        self.start_session()
         self.launch(callback_function=callback)

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import requests
+import spotipy
+import time
 
 from pychromecast.controllers import BaseController
 from ..config import APP_SPOTIFY
@@ -24,6 +26,8 @@ class SpotifyController(BaseController):
         self.session_started = False
         self.token = None
         self.expiration_date = None
+        self.client = None
+
 
     def receive_message(self, message, data):
         self.logger.debug("Cast message: {}".format(data))
@@ -62,7 +66,6 @@ class SpotifyController(BaseController):
         expiration = response.cookies['wp_expiration']
         self.expiration_date = int(expiration)//1000
 
-        # return response.cookies['wp_access_token']
 
     def start_session(self):
         # arbitrary value and can be static
@@ -94,3 +97,7 @@ class SpotifyController(BaseController):
 
         self.start_session()
         self.launch(callback_function=callback)
+
+        #TODO: Remove sleep and find another way to wait for app to go up completely
+        time.sleep(5)
+        self.client = spotipy.Spotify(auth=self.token)

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -88,15 +88,13 @@ class SpotifyController(BaseController):
         """ Play a single song with it's Spotify URI. """
         if self.device_id is None:
             raise Exception("No device id. Try launching app again")
-        else:
-            self.client.start_playback(device_id=self.device_id, uris=[uri])
+        self.client.start_playback(device_id=self.device_id, uris=[uri])
 
     def play_songs(self, uris):
         """ Play several songs with a list of uris. """
         if self.device_id is None:
             raise Exception("No device id. Try launching app again")
-        else:
-            self.client.start_playback(device_id=self.device_id, uris=uris)
+        self.client.start_playback(device_id=self.device_id, uris=uris)
 
     def play_context(self, context_uri, offset=None):
         """ Play a Spotify context.
@@ -104,6 +102,5 @@ class SpotifyController(BaseController):
         """
         if self.device_id is None:
             raise Exception("No device id. Try launching app again")
-        else:
-            self.client.start_playback(device_id=self.device_id,
-                                       context_uri=context_uri, offset=offset)
+        self.client.start_playback(device_id=self.device_id,
+                                   context_uri=context_uri, offset=offset)

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -132,5 +132,9 @@ class SpotifyController(BaseController):
 
         self.client.start_playback(device_id=self.device_id, uris=uris)
 
+    def play_context(self, context_uri, offset=None):
+
+        self.client.start_playback(device_id=self.device_id,context_uri=context_uri, offset=offset)
+
 
 

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -1,0 +1,22 @@
+from pychromecast.controllers import BaseController
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+class SpotifyController(BaseController):
+    def __init__(self):
+        super(SpotifyController, self).__init__(
+            "urn:x-cast:com.spotify.chromecast.secure.v1", "CC32E753")
+
+    def receive_message(self, message, data):
+        print("Cast message: {}".format(data))
+
+        return True  # indicate you handled this message
+
+    def start_playback(self, credentials):
+
+        def callback():
+            self.send_message({"type":"setCredentials","credentials":credentials},inc_session_id=True)
+
+        self.launch(callback_function=callback)

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -2,10 +2,9 @@
 Controller to interface with the DashCast app namespace.
 """
 import logging
-import os
 import time
-import requests
 import spotipy
+import spotify_token
 
 from pychromecast.controllers import BaseController
 from ..config import APP_SPOTIFY
@@ -13,9 +12,6 @@ from ..config import APP_SPOTIFY
 logging.basicConfig(level=logging.DEBUG)
 
 APP_NAMESPACE = "urn:x-cast:com.spotify.chromecast.secure.v1"
-USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) \
-AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"
-
 TYPE_STATUS = "setCredentials"
 
 # pylint: disable=too-many-instance-attributes
@@ -44,68 +40,7 @@ class SpotifyController(BaseController):
         """ Currently not doing anything with received messages. """
         return True
 
-    def _get_csrf(self, session, cookies):
-        """ Get CSRF token for Spotify login. """
-        headers = {'user-agent': USER_AGENT}
 
-        response = session.get("https://accounts.spotify.com/login",
-                               headers=headers, cookies=cookies)
-        response.raise_for_status()
-
-        return response.cookies['csrf_token']
-
-    # pylint: disable=too-many-arguments
-    def _login(self, session, cookies, username, password, csrf_token):
-        """ Logs in with CSRF token and cookie within session. """
-        headers = {'user-agent': USER_AGENT}
-
-        data = {"remember": False, "username": username, "password": password,
-                "csrf_token": csrf_token}
-
-        response = session.post("https://accounts.spotify.com/api/login",
-                                data=data, cookies=cookies, headers=headers)
-
-        response.raise_for_status()
-
-    def _get_access_token(self, session, cookies):
-        """ Gets access token after login has been successful. """
-        headers = {'user-agent': USER_AGENT}
-
-        response = session.get("https://open.spotify.com/browse",
-                               headers=headers, cookies=cookies)
-        response.raise_for_status()
-
-        self.token = response.cookies['wp_access_token']
-
-        expiration = response.cookies['wp_expiration']
-        self.expiration_date = int(expiration)//1000
-
-    # Access token provided by spotipy does not have enough permissions to start
-    # Spotify on Chromecast
-    def start_session(self):
-        """ Starts session to get access token. """
-
-        # arbitrary value and can be static
-        cookies = {"__bon": "MHwwfC01ODc4MjExMzJ8LTI0Njg4NDg3NTQ0fDF8MXwxfDE="}
-
-        if self.username is None:
-            self.username = os.getenv("SPOTIFY_USERNAME")
-
-        if self.password is None:
-            self.password = os.getenv("SPOTIFY_PASS")
-
-        if self.username is None or self.password is None:
-            raise Exception("No username or password")
-
-        session = requests.Session()
-        token = self. _get_csrf(session, cookies)
-
-        self._login(session, cookies, self.username, self.password, token)
-        self._get_access_token(session, cookies)
-
-        self.session_started = True
-
-        return self.token
 
     def launch_app(self):
         """ Launch main application """
@@ -121,7 +56,12 @@ class SpotifyController(BaseController):
             self.launch(callback_function=callback)
         else:
             self.logger.debug("Creating new token")
-            self.start_session()
+
+            data = spotify_token.start_session(self.username, self.password)
+            self.session_started = True
+            self.token = data[0]
+            self.expiration_date = data[1]
+
             self.logger.debug("Token is: %s", self.token)
             self.launch(callback_function=callback)
 

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -80,7 +80,7 @@ class SpotifyController(BaseController):
 
         for device in devices_available['devices']:
             self.logger.debug(device)
-            if device['name'] == self.cast_name:
+            if device['name'] == self.cast_name and device['type'] == 'CastVideo':
                 return device['id']
         return None
 

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -6,7 +6,7 @@ import time
 import spotipy
 import spotify_token
 
-from pychromecast.controllers import BaseController
+from . import BaseController
 from ..config import APP_SPOTIFY
 
 logging.basicConfig(level=logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.0
 protobuf>=3.0.0
 zeroconf>=0.17.7
+spotify-token>=0.1.0
 git+https://github.com/plamere/spotipy.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.0
 protobuf>=3.0.0
 zeroconf>=0.17.7
+git+https://github.com/plamere/spotipy.git


### PR DESCRIPTION
Continuation of #227 
Previous commits have been removed and only Spotify Controller commits remain.

I implemented some of the suggestions made on the other pull request like:
- Poll the received messages for `setCredentialsResponse`. This can help be more accurate for when the Spotify up is completely finished.
- Removed the access token logic to it's own repository

Let me know if you have any questions or suggestions.
Thanks!