### PR TITLE
Allow users to pass the force_launch flag when launching an app

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -257,11 +257,11 @@ class Chromecast(object):
         if status:
             self.status_event.set()
 
-    def start_app(self, app_id):
+    def start_app(self, app_id, force_launch=False):
         """ Start an app on the Chromecast. """
         self.logger.info("Starting app %s", app_id)
 
-        self.socket_client.receiver_controller.launch_app(app_id)
+        self.socket_client.receiver_controller.launch_app(app_id, force_launch)
 
     def quit_app(self):
         """ Tells the Chromecast to quit current app_id. """


### PR DESCRIPTION
Some apps crash or become unresponsive. This flag allows us to restart the app without having to go all the way to backdrop and getting back.

A very interesting use case for this is DashCast, which pychromecast already supports and in a way, becomes unresponsive by design.

More specifically, we would need it here:

https://github.com/skorokithakis/catt/pull/102/files#diff-3640ca096ed1132eacda8076da173e1dR480
