### PR TITLE
Create spotify_exemple_2.py

### DIFF
--- a/examples/spotify_exemple_2.py
+++ b/examples/spotify_exemple_2.py
@@ -1,0 +1,43 @@
+"""
+Test Spotify Controller.
+NOTE: You need to install the spotipy and spotify-token dependencies.
+
+This can be done by running the following:
+pip install git+https://github.com/plamere/spotipy.git
+
+You must manually enter the token that you can retrieve into your 
+cookie in the spotify web app (wp_access_token)
+"""
+import pychromecast
+from pychromecast.controllers.spotify import SpotifyController
+import spotipy
+
+chromecasts = pychromecast.get_chromecasts()
+cast = chromecasts[1]
+
+device_id = None
+
+if cast:
+    print("I test with device : {}".format(cast.name))
+
+    print("Open Spotify web app (https://open.spotify.com) in your browser and "
+        "search the wp_access_token in cookies")
+
+    access_token = input("access token : ").strip()
+
+    client = spotipy.Spotify(auth=access_token)
+    print("Client Spotify connected : {}".format(client.me().get('id')))
+
+    print("Test launch spotify app in chromecast {}".format(cast.name))
+    sp = SpotifyController(access_token)
+    cast.register_handler(sp)
+    sp.launch_app()
+
+    devices_available = client.devices()
+
+    for device in devices_available['devices']:
+        if device['name'] == cast.name and device['type'] == 'CastVideo':
+            device_id = device['id']
+            break
+
+    client.start_playback(device_id=device_id, uris=["spotify:track:3Zwu2K0Qa5sT6teCCHPShP"])


### PR DESCRIPTION
Script for test pychromecast with Spotify but with the manual entry of the token. Because the dependency spotify_token method don't work ( Spotify added a reCAPTCHA button).  To test because SpotifyController don't work for me...