### PR TITLE
Don't throw when closing socket.

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -6,7 +6,7 @@ version of this code: https://github.com/minektur/chromecast-python-poc.
 Without him this would not have been possible.
 """
 # Pylint does not understand the protobuf objects correctly
-# pylint: disable=no-member
+# pylint: disable=no-member, C0302
 
 import errno
 import json

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -490,7 +490,11 @@ class SocketClient(threading.Thread):
             except Exception:  # pylint: disable=broad-except
                 pass
 
-        self.socket.close()
+        try:
+            self.socket.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
         self._report_connection_status(
             ConnectionStatus(CONNECTION_STATUS_DISCONNECTED,
                              NetworkAddress(self.host, self.port)))


### PR DESCRIPTION
Attempt to improve stability of audio groups (home-assistant/home-assistant#13530)

Root cause of home-assistant/home-assistant#13530 is that Home Assistant does not reconnect after group leader change. The issue is easy to reproduce by rebooting members of an audio group repeatedly.

Several times, I've seen it happening after failing to cleanup the socket client:
```
Exception in thread Thread-30:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/erik/github/home-assistant_fork/lib/python3.6/site-packages/pychromecast/socket_client.py", line 348, in run
    self._cleanup()
  File "/home/erik/github/home-assistant_fork/lib/python3.6/site-packages/pychromecast/socket_client.py", line 496, in _cleanup
    self.socket.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

With this change the stability seems to be significantly improved, although logs indicate there might also be bugs in python-zeroconf.

Edit: Not a fix, still possible to trigger the bug.