### PR TITLE
Exponential backoff of mdns service resolution retries

### DIFF
--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -6,9 +6,8 @@ from uuid import UUID
 
 import logging
 import requests
-import socket
 
-from .discovery import get_info_from_service
+from .discovery import get_info_from_service, get_host_from_service_info
 
 XML_NS_UPNP_DEVICE = "{urn:schemas-upnp-org:device-1-0}"
 
@@ -53,13 +52,7 @@ def get_device_status(host, services=None, zconf=None):
         if not host:
             for service in services.copy():
                 service_info = get_info_from_service(service, zconf)
-                if (service_info and
-                        (service_info.server or service_info.address)):
-                    host = None
-                    if service_info.address:
-                        host = socket.inet_ntoa(service_info.address)
-                    else:
-                        host = service_info.server.lower()
+                host, _ = get_host_from_service_info(service_info)
                 if host:
                     _LOGGER.debug("Resolved service %s to %s", service, host)
                     break

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -152,3 +152,17 @@ def get_info_from_service(service, zconf):
     except IOError:
         pass
     return service_info
+
+
+def get_host_from_service_info(service_info):
+    """ Get hostname or IP from service_info. """
+    host = None
+    port = None
+    if (service_info and service_info.port and
+            (service_info.server or service_info.address)):
+        if service_info.address:
+            host = socket.inet_ntoa(service_info.address)
+        else:
+            host = service_info.server.lower()
+        port = service_info.port
+    return (host, port)


### PR DESCRIPTION
Exponential backoff of mdns service resolution retries since each resolution request may generate a large number of packets with detrimental side effects.

Also:
- Connect to IP, if known, instead of to host in case mdns name resolution is not enabled
- Improve debug prints to include friendly name if known

See home-assistant/home-assistant#21075