### PR TITLE
Improve exponential backoff of mdns service resolution retries

### DIFF
--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -34,6 +34,10 @@ class CastListener(object):
         _LOGGER.debug("remove_service %s, %s", typ, name)
         service = self.services.pop(name, None)
 
+        if not service:
+            _LOGGER.debug("remove_service unknown %s, %s", typ, name)
+            return
+
         if self.remove_callback:
             self.remove_callback(name, service)
 
@@ -52,6 +56,7 @@ class CastListener(object):
             tries += 1
 
         if not service:
+            _LOGGER.debug("add_service failed to add %s, %s", typ, name)
             return
 
         def get_value(key):


### PR DESCRIPTION
Improve exponential backoff if mdns service resolution introduced in #268 by also backing off if service resolution fails.
Also, small do not issue a `remove_service` callback if the service is unknown.