### PR TITLE
Do not automatically start worker thread and connect in Chromecast constructor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,8 @@ How to use
     ['Dev', 'Living Room', 'Den', 'Bedroom']
 
     >> cast = next(cc for cc in chromecasts if cc.device.friendly_name == "Living Room")
+    >> # Start worker thread
+    >> cast.start()
     >> # Wait for cast device to be ready
     >> cast.wait()
     >> print(cast.device)

--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,7 @@ How to use
     ['Dev', 'Living Room', 'Den', 'Bedroom']
 
     >> cast = next(cc for cc in chromecasts if cc.device.friendly_name == "Living Room")
-    >> # Start worker thread
-    >> cast.start()
-    >> # Wait for cast device to be ready
+    >> # Start worker thread and wait for cast device to be ready
     >> cast.wait()
     >> print(cast.device)
     DeviceStatus(friendly_name='Living Room', model_name='Chromecast', manufacturer='Google Inc.', uuid=UUID('df6944da-f016-4cb8-97d0-3da2ccaa380b'), cast_type='cast')

--- a/examples/blocking.py
+++ b/examples/blocking.py
@@ -19,6 +19,7 @@ if len(casts) == 0:
     print("No Devices Found")
     exit()
 cast = casts[0]
+cast.start()
 
 print()
 print(cast.device)

--- a/examples/dashcast_blocking.py
+++ b/examples/dashcast_blocking.py
@@ -21,6 +21,7 @@ if len(casts) == 0:
     exit()
 
 cast = casts[0]
+cast.start()
 
 d = dashcast.DashCastController()
 cast.register_handler(d)

--- a/examples/non_blocking.py
+++ b/examples/non_blocking.py
@@ -20,6 +20,7 @@ def your_main_loop():
     t = 1
     cast = None
     def callback(chromecast):
+        chromecast.connect()
         nonlocal cast
         cast = chromecast
         stop_discovery()

--- a/examples/simple_listener_example.py
+++ b/examples/simple_listener_example.py
@@ -30,6 +30,7 @@ class StatusMediaListener:
 chromecasts = pychromecast.get_chromecasts()
 chromecast = next(cc for cc in chromecasts
                   if cc.device.friendly_name == "Living Room Speaker")
+chromecast.start()
 
 listenerCast = StatusListener(chromecast.name, chromecast)
 chromecast.register_status_listener(listenerCast)

--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -13,6 +13,7 @@ import spotipy
 
 chromecasts = pychromecast.get_chromecasts()
 cast = chromecasts[0]
+cast.start()
 
 CAST_NAME = "My Chromecast"
 device_id = None

--- a/examples/youtube_example.py
+++ b/examples/youtube_example.py
@@ -17,6 +17,7 @@ VIDEO_ID = ""
 
 chromecasts = pychromecast.get_chromecasts()
 cast = next(cc for cc in chromecasts if cc.device.friendly_name == CAST_NAME)
+cast.start()
 cast.wait()
 yt = YouTubeController()
 cast.register_handler(yt)

--- a/examples/youtube_example.py
+++ b/examples/youtube_example.py
@@ -17,7 +17,6 @@ VIDEO_ID = ""
 
 chromecasts = pychromecast.get_chromecasts()
 cast = next(cc for cc in chromecasts if cc.device.friendly_name == CAST_NAME)
-cast.start()
 cast.wait()
 yt = YouTubeController()
 cast.register_handler(yt)

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -26,7 +26,6 @@ IGNORE_CEC = []
 _LOGGER = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-arguments
 def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
                               blocking=True):
     """Creates a Chromecast object from a zeroconf host."""
@@ -46,7 +45,6 @@ def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
                       blocking=blocking)
 
 
-# pylint: disable=too-many-arguments
 def _get_chromecast_from_service(services, tries=None, retry_wait=None,
                                  timeout=None, blocking=True):
     """Creates a Chromecast object from a zeroconf service."""
@@ -189,9 +187,9 @@ class Chromecast(object):
         self.status_event = threading.Event()
 
         self.socket_client = socket_client.SocketClient(
-            host, port=port, cast_type=self.device.cast_type, tries=tries,
-            timeout=timeout, retry_wait=retry_wait, blocking=blocking,
-            services=services, zconf=zconf)
+            host, port=port, cast_type=self.device.cast_type,
+            tries=tries, timeout=timeout, retry_wait=retry_wait,
+            blocking=blocking, services=services, zconf=zconf)
 
         receiver_controller = self.socket_client.receiver_controller
         receiver_controller.register_status_listener(self)

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -328,6 +328,13 @@ class Chromecast(object):
         """
         self.status_event.wait(timeout=timeout)
 
+    def connect(self):
+        """ Connect to the chromecast.
+
+            Must only be called if the worker thread will not be started.
+        """
+        self.socket_client.connect()
+
     def disconnect(self, timeout=None, blocking=True):
         """
         Disconnects the chromecast and waits for it to terminate.

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -319,6 +319,8 @@ class Chromecast(object):
         Waits until the cast device is ready for communication. The device
         is ready as soon a status message has been received.
 
+        If the worker thread is not already running, it will be started.
+
         If the status has already been received then the method returns
         immediately.
 
@@ -326,6 +328,8 @@ class Chromecast(object):
                         operation in seconds (or fractions thereof). Or None
                         to block forever.
         """
+        if not self.socket_client.isAlive():
+            self.socket_client.start()
         self.status_event.wait(timeout=timeout)
 
     def connect(self):

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -119,7 +119,7 @@ def get_chromecasts(tries=None, retry_wait=None, timeout=None,
         return internal_stop
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class Chromecast(object):
     """
     Class to interface with a ChromeCast.

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -26,6 +26,7 @@ IGNORE_CEC = []
 _LOGGER = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-arguments
 def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
                               blocking=True, defer_connect=False):
     """Creates a Chromecast object from a zeroconf host."""
@@ -45,6 +46,7 @@ def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
                       blocking=blocking, defer_connect=defer_connect)
 
 
+# pylint: disable=too-many-arguments
 def _get_chromecast_from_service(services, tries=None, retry_wait=None,
                                  timeout=None, blocking=True,
                                  defer_connect=False):

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
-                              blocking=True):
+                              blocking=True, defer_connect=False):
     """Creates a Chromecast object from a zeroconf host."""
     # Build device status from the mDNS info, this information is
     # the primary source and the remaining will be fetched
@@ -42,11 +42,12 @@ def _get_chromecast_from_host(host, tries=None, retry_wait=None, timeout=None,
     )
     return Chromecast(host=ip_address, port=port, device=device, tries=tries,
                       timeout=timeout, retry_wait=retry_wait,
-                      blocking=blocking)
+                      blocking=blocking, defer_connect=defer_connect)
 
 
 def _get_chromecast_from_service(services, tries=None, retry_wait=None,
-                                 timeout=None, blocking=True):
+                                 timeout=None, blocking=True,
+                                 defer_connect=False):
     """Creates a Chromecast object from a zeroconf service."""
     # Build device status from the mDNS service name info, this
     # information is the primary source and the remaining will be
@@ -61,7 +62,8 @@ def _get_chromecast_from_service(services, tries=None, retry_wait=None,
     )
     return Chromecast(host=None, device=device, tries=tries, timeout=timeout,
                       retry_wait=retry_wait, blocking=blocking,
-                      services=services, zconf=zconf)
+                      services=services, zconf=zconf,
+                      defer_connect=defer_connect)
 
 
 # pylint: disable=too-many-locals
@@ -145,6 +147,7 @@ class Chromecast(object):
         blocking = kwargs.pop('blocking', True)
         services = kwargs.pop('services', None)
         zconf = kwargs.pop('zconf', True)
+        defer_connect = kwargs.pop('defer_connect', True)
 
         self.logger = logging.getLogger(__name__)
 
@@ -187,9 +190,9 @@ class Chromecast(object):
         self.status_event = threading.Event()
 
         self.socket_client = socket_client.SocketClient(
-            host, port=port, cast_type=self.device.cast_type,
-            tries=tries, timeout=timeout, retry_wait=retry_wait,
-            blocking=blocking, services=services, zconf=zconf)
+            host, port=port, cast_type=self.device.cast_type, tries=tries,
+            timeout=timeout, retry_wait=retry_wait, blocking=blocking,
+            services=services, zconf=zconf, defer_connect=defer_connect)
 
         receiver_controller = self.socket_client.receiver_controller
         receiver_controller.register_status_listener(self)

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -134,7 +134,7 @@ LaunchFailure = namedtuple('LaunchStatus',
                            ['reason', 'app_id', 'request_id'])
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class SocketClient(threading.Thread):
     """
     Class to interact with a Chromecast through a socket.
@@ -151,7 +151,6 @@ class SocketClient(threading.Thread):
                        which is 5 seconds.
     """
 
-    # pylint:disable=too-many-statements
     def __init__(self, host, port=None, cast_type=CAST_TYPE_CHROMECAST,
                  **kwargs):
         tries = kwargs.pop('tries', None)
@@ -364,7 +363,7 @@ class SocketClient(threading.Thread):
         except ChromecastConnectionError:
             self._report_connection_status(
                 ConnectionStatus(CONNECTION_STATUS_DISCONNECTED,
-                NetworkAddress(self.host, self.port)))
+                                 NetworkAddress(self.host, self.port)))
             return
 
     def disconnect(self):
@@ -425,7 +424,7 @@ class SocketClient(threading.Thread):
         except ChromecastConnectionError:
             self._report_connection_status(
                 ConnectionStatus(CONNECTION_STATUS_DISCONNECTED,
-                NetworkAddress(self.host, self.port)))
+                                 NetworkAddress(self.host, self.port)))
             return
 
         self.heartbeat_controller.reset()

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -354,6 +354,19 @@ class SocketClient(threading.Thread):
                           self.fn or self.host, self.port)
         raise ChromecastConnectionError("Failed to connect")
 
+    def connect(self):
+        """ Connect socket connection to Chromecast device.
+
+            Must only be called if the worker thread will not be started.
+        """
+        try:
+            self.initialize_connection()
+        except ChromecastConnectionError:
+            self._report_connection_status(
+                ConnectionStatus(CONNECTION_STATUS_DISCONNECTED,
+                NetworkAddress(self.host, self.port)))
+            return
+
     def disconnect(self):
         """ Disconnect socket connection to Chromecast device """
         self.stop.set()

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -134,7 +134,7 @@ LaunchFailure = namedtuple('LaunchStatus',
                            ['reason', 'app_id', 'request_id'])
 
 
-# pylint: disable=too-many-instance-attributes, too-many-public-methods
+# pylint: disable=too-many-instance-attributes
 class SocketClient(threading.Thread):
     """
     Class to interact with a Chromecast through a socket.

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -151,6 +151,7 @@ class SocketClient(threading.Thread):
                        which is 5 seconds.
     """
 
+    # pylint:disable=too-many-statements
     def __init__(self, host, port=None, cast_type=CAST_TYPE_CHROMECAST,
                  **kwargs):
         tries = kwargs.pop('tries', None)
@@ -417,10 +418,7 @@ class SocketClient(threading.Thread):
     def run(self):
         """ Start polling the socket. """
         self.heartbeat_controller.reset()
-        if self.defer_connect:
-            self._force_recon = True
-        else:
-            self._force_recon = False
+        self._force_recon = self.defer_connect
         logging.debug("Thread started...")
         while not self.stop.is_set():
 


### PR DESCRIPTION
Do not automatically start worker thread or connect in `Chromecast` constructor.

This is a breaking change, and the user will now have to call either of:
- `Chromecast.start()`: Start the worker thread and connect to the chromecast device. Connection status will be reported through the listener registered in `Chromecast.register_connection_listener`.
- `Chromecast.wait()`: Wait for connection, this will also start the worker thread if it has not been started.
- `Chromecast.connect()`: Connect to the chromecast. This must only be called if the worker thread has not been started. Connection status will be reported through the listener registered in `Chromecast.register_connection_listener`.

Background:
The automatic connect in the constructor meant that the constructor would hang forever if the number of retries was unlimited and the chromecast could not be found.
It was also a bit unnatural to start the worker thread in the constructor.