### PR TITLE
Fix Spotify playback

### DIFF
--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -41,7 +41,8 @@ class SpotifyController(BaseController):
         def callback():
             """Callback function"""
             self.send_message({"type": TYPE_STATUS,
-                               "credentials": self.access_token})
+                               "credentials": self.access_token,
+                               "expiresIn": 3600})
 
         self.launch(callback_function=callback)
 


### PR DESCRIPTION
Spotify now requires the expiresIn token in the message.
Tested to work with Harman Kardon Google Home smart speaker and Chromecast stick v1.