### PR TITLE
Dynamic auth token

### DIFF
--- a/examples/spotify_example.py
+++ b/examples/spotify_example.py
@@ -33,10 +33,11 @@ if cast:
 
     data = st.start_session("SPOTIFY_USERNAME", "SPOTIFY_PASSWORD")
     access_token = data[0]
+    expires = data[1] - int(time.time())
 
     client = spotipy.Spotify(auth=access_token)
 
-    sp = SpotifyController(access_token)
+    sp = SpotifyController(access_token, expires)
     cast.register_handler(sp)
     sp.launch_app()
 

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -20,8 +20,10 @@ class SpotifyController(BaseController):
     # pylint: disable=useless-super-delegation
     # The pylint rule useless-super-delegation doesn't realize
     # we are setting default values here.
-    def __init__(self, access_token, expires=3600):
+    def __init__(self, access_token, expires):
         super(SpotifyController, self).__init__(APP_NAMESPACE, APP_SPOTIFY)
+        if access_token is None or expires is None:
+            raise ValueError("access_token and expires cannot be empty")
 
         self.logger = logging.getLogger(__name__)
         self.session_started = False

--- a/pychromecast/controllers/spotify.py
+++ b/pychromecast/controllers/spotify.py
@@ -20,12 +20,13 @@ class SpotifyController(BaseController):
     # pylint: disable=useless-super-delegation
     # The pylint rule useless-super-delegation doesn't realize
     # we are setting default values here.
-    def __init__(self, access_token):
+    def __init__(self, access_token, expires=3600):
         super(SpotifyController, self).__init__(APP_NAMESPACE, APP_SPOTIFY)
 
         self.logger = logging.getLogger(__name__)
         self.session_started = False
         self.access_token = access_token
+        self.expires = expires
         self.is_launched = False
     # pylint: enable=useless-super-delegation
 
@@ -48,7 +49,7 @@ class SpotifyController(BaseController):
             """Callback function"""
             self.send_message({"type": TYPE_STATUS,
                                "credentials": self.access_token,
-                               "expiresIn": 3600})
+                               "expiresIn": self.expires})
 
         self.launch(callback_function=callback)
 


### PR DESCRIPTION
This PR is a start for dynamic tokens for Spotify after comments in https://github.com/balloob/pychromecast/pull/275#discussion_r266249793.
There are a couple of problems that need to be addressed in order to go all the way.

The first problem is that in order for the correct level of authentication we need to use `spotify_token` which does a normal web browser login and returns the token and the expiration in epoch.
There is no refresh token AFAIK when using this token. What can be added is a check in [spotify](https://github.com/balloob/pychromecast/blob/master/pychromecast/controllers/spotify.py) for the expiration or is there a better way?

The other problem is that I don't really know how this code is used as I don't see it in HASS. I will tinker on a custom_component which will make use of starting a spotify playback but then I think the normal media player spotify can be used for controlling the  playback with spotify connect.