### PR TITLE
Fix broken attempt to update status during tear down

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -1092,7 +1092,6 @@ class ReceiverController(BaseController):
         self.launch_failure = None
         self.app_to_launch = None
         self.app_launch_event.clear()
-        self._report_status()
 
         self._status_listeners[:] = []
 


### PR DESCRIPTION
Fix broken attempt to update status during tear down, as reported in home-assistant/home-assistant#23445

This is not possible because the status object is set to `None` here: 
https://github.com/balloob/pychromecast/blob/958c683fc74f8e8746ec0bf5c88282c71a60c933/pychromecast/socket_client.py#L1091