### PR TITLE
Catch IndexError while parsing STATUS message.

### DIFF
--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -1005,7 +1005,7 @@ class ReceiverController(BaseController):
 
         try:
             app_data = data['applications'][0]
-        except KeyError:
+        except (KeyError, IndexError):
             app_data = {}
 
         is_audio = cast_type in (CAST_TYPE_AUDIO, CAST_TYPE_GROUP)


### PR DESCRIPTION
Catch IndexError exceptions while parsing STATUS messages that contain lists of empty dictionaries.

The following behavior was observed while executing the following call:
`chromecast.media_controller.block_until_active(timeout=remaining_time)`

`
ERROR:pychromecast.socket_client:[192.168.1.88:8009] Exception caught while sending message to controller ReceiverController: Message urn:x-cast:com.google.cast.receiver from receiver-0 to sender-0: {'requestId': 1, 'status': {'applications': [], 'userEq': {}, 'volume': {'controlType': 'attenuation', 'level': 1.0, 'muted': False, 'stepInterval': 0.05000000074505806}}, 'type': 'RECEIVER_STATUS'}
Traceback (most recent call last):
  File "/home/taylor/source/repos/otto/venv/lib/python3.6/site-packages/pychromecast/socket_client.py", line 565, in _route_message
    message, data)
  File "/home/taylor/source/repos/otto/venv/lib/python3.6/site-packages/pychromecast/socket_client.py", line 899, in receive_message
    self._process_get_status(data)
  File "/home/taylor/source/repos/otto/venv/lib/python3.6/site-packages/pychromecast/socket_client.py", line 1031, in _process_get_status
    status = self._parse_status(data, self.cast_type)
  File "/home/taylor/source/repos/otto/venv/lib/python3.6/site-packages/pychromecast/socket_client.py", line 1009, in _parse_status
    app_data = data['applications'][0]
IndexError: list index out of range
`

You can easily reproduce this by adding:
`data['applications'] = []`
prior to accessing the `applications` dictionary to retrieve `app_data` in `socket_client.py` (line 1007).