### PR TITLE
Drop support for Py34, Py35

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ pychromecast |Build Status|
 .. |Build Status| image:: https://travis-ci.org/balloob/pychromecast.svg?branch=master
    :target: https://travis-ci.org/balloob/pychromecast
 
-Library for Python 3.4+ to communicate with the Google Chromecast. It
+Library for Python 3.6+ to communicate with the Google Chromecast. It
 currently supports:
 
 -  Auto discovering connected Chromecasts on the network


### PR DESCRIPTION
Drop support for Python 3.4 and Python 3.5. They are old, even Debian Stable is running Py 3.7.