### PR TITLE
Get ipaddress the same way as code examples in zeroconf

### DIFF
--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -67,8 +67,8 @@ class CastListener:
                 return value
             return value.decode("utf-8")
 
-        addresses = ["%s" % socket.inet_ntoa(addr) for addr in service.addresses]
-        host = addresses[0] if len(addresses) > 0 else service.server
+        addresses = service.parsed_addresses()
+        host = addresses[0] if addresses else service.server
 
         model_name = get_value("md")
         uuid = get_value("id")

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -43,6 +43,7 @@ class CastListener:
 
     def add_service(self, zconf, typ, name):
         """ Add a service to the collection. """
+        import socket
         service = None
         tries = 0
         _LOGGER.debug("add_service %s, %s", typ, name)
@@ -67,8 +68,8 @@ class CastListener:
                 return value
             return value.decode("utf-8")
 
-        ips = zconf.cache.entries_with_name(service.server.lower())
-        host = repr(ips[0]) if ips else service.server
+        addresses = ["%s" % socket.inet_ntoa(addr) for addr in service.addresses]
+        host = addresses[0] if len(addresses) > 0 else service.server
 
         model_name = get_value("md")
         uuid = get_value("id")

--- a/pychromecast/discovery.py
+++ b/pychromecast/discovery.py
@@ -43,7 +43,6 @@ class CastListener:
 
     def add_service(self, zconf, typ, name):
         """ Add a service to the collection. """
-        import socket
         service = None
         tries = 0
         _LOGGER.debug("add_service %s, %s", typ, name)


### PR DESCRIPTION
zero-conf 0.24.4 changes the way the information from `zconf.cache.entries_with_name` is returned. According to @jstasiak  the current way is [unsupported](https://github.com/balloob/pychromecast/issues/332#issuecomment-576258110). 
This PR gets the ipaddress the official way (https://github.com/jstasiak/python-zeroconf/blob/master/examples/browser.py#L22).

