### PR TITLE
Update zeroconf requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.0
 protobuf>=3.0.0
-zeroconf>=0.17.7
+zeroconf>=0.24.4
 casttube>=0.2.0


### PR DESCRIPTION
In the recently merged zeroconf related PR (#337), there is usage of `zeroconf`s [`parsed_addresses`](https://github.com/jstasiak/python-zeroconf/blob/29432bfffd057cf4da7636ba0c28c9d8a7ad4357/zeroconf/__init__.py#L1611), which appears to have been introduced in `0.24.0`. So I updated the requirements. :tv: 