### PR TITLE
Lookup manufacturer, remove multizone helper.

### DIFF
--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -38,7 +38,7 @@ def _get_chromecast_from_host(
     ip_address, port, uuid, model_name, friendly_name = host
     _LOGGER.debug("_get_chromecast_from_host %s", host)
     cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
-    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Unknown manufacturer")
+    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Google Inc.")
     device = DeviceStatus(
         friendly_name=friendly_name,
         model_name=model_name,
@@ -67,7 +67,7 @@ def _get_chromecast_from_service(
     services, zconf, uuid, model_name, friendly_name = services
     _LOGGER.debug("_get_chromecast_from_service %s", services)
     cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
-    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Unknown manufacturer")
+    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Google Inc.")
     device = DeviceStatus(
         friendly_name=friendly_name,
         model_name=model_name,

--- a/pychromecast/__init__.py
+++ b/pychromecast/__init__.py
@@ -14,9 +14,8 @@ from .dial import (
     get_device_status,
     reboot,
     DeviceStatus,
-    CAST_TYPES,
-    CAST_TYPE_CHROMECAST,
 )
+from .const import CAST_MANUFACTURERS, CAST_TYPES, CAST_TYPE_CHROMECAST
 from .controllers.media import STREAM_TYPE_BUFFERED  # noqa
 
 __all__ = ("__version__", "__version_info__", "get_chromecasts", "Chromecast")
@@ -39,10 +38,11 @@ def _get_chromecast_from_host(
     ip_address, port, uuid, model_name, friendly_name = host
     _LOGGER.debug("_get_chromecast_from_host %s", host)
     cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
+    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Unknown manufacturer")
     device = DeviceStatus(
         friendly_name=friendly_name,
         model_name=model_name,
-        manufacturer=None,
+        manufacturer=manufacturer,
         uuid=uuid,
         cast_type=cast_type,
     )
@@ -67,10 +67,11 @@ def _get_chromecast_from_service(
     services, zconf, uuid, model_name, friendly_name = services
     _LOGGER.debug("_get_chromecast_from_service %s", services)
     cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
+    manufacturer = CAST_MANUFACTURERS.get(model_name.lower(), "Unknown manufacturer")
     device = DeviceStatus(
         friendly_name=friendly_name,
         model_name=model_name,
-        manufacturer=None,
+        manufacturer=manufacturer,
         uuid=uuid,
         cast_type=cast_type,
     )

--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -1,0 +1,29 @@
+"""
+Chromecast constants
+"""
+# Regular chromecast, supports video/audio
+CAST_TYPE_CHROMECAST = "cast"
+# Cast Audio device, supports only audio
+CAST_TYPE_AUDIO = "audio"
+# Cast Audio group device, supports only audio
+CAST_TYPE_GROUP = "group"
+
+MF_GOOGLE = "Google Inc."
+
+CAST_TYPES = {
+    "chromecast": CAST_TYPE_CHROMECAST,
+    "eureka dongle": CAST_TYPE_CHROMECAST,
+    "chromecast audio": CAST_TYPE_AUDIO,
+    "google home": CAST_TYPE_AUDIO,
+    "google home mini": CAST_TYPE_AUDIO,
+    "google cast group": CAST_TYPE_GROUP,
+}
+
+CAST_MANUFACTURERS = {
+    "chromecast": MF_GOOGLE,
+    "eureka dongle": MF_GOOGLE,
+    "chromecast audio": MF_GOOGLE,
+    "google home": MF_GOOGLE,
+    "google home mini": MF_GOOGLE,
+}
+

--- a/pychromecast/const.py
+++ b/pychromecast/const.py
@@ -19,11 +19,7 @@ CAST_TYPES = {
     "google cast group": CAST_TYPE_GROUP,
 }
 
+# Known models not manufactured by Google
 CAST_MANUFACTURERS = {
-    "chromecast": MF_GOOGLE,
-    "eureka dongle": MF_GOOGLE,
-    "chromecast audio": MF_GOOGLE,
-    "google home": MF_GOOGLE,
-    "google home mini": MF_GOOGLE,
 }
 

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -94,7 +94,3 @@ def get_device_status(host, services=None, zconf=None):
 DeviceStatus = namedtuple(
     "DeviceStatus", ["friendly_name", "model_name", "manufacturer", "uuid", "cast_type"]
 )
-
-MultizoneInfo = namedtuple("MultizoneInfo", ["friendly_name", "uuid"])
-
-MultizoneStatus = namedtuple("MultizoneStatus", ["dynamic_groups", "groups"])

--- a/pychromecast/dial.py
+++ b/pychromecast/dial.py
@@ -13,22 +13,6 @@ XML_NS_UPNP_DEVICE = "{urn:schemas-upnp-org:device-1-0}"
 
 FORMAT_BASE_URL = "http://{}:8008"
 
-# Regular chromecast, supports video/audio
-CAST_TYPE_CHROMECAST = "cast"
-# Cast Audio device, supports only audio
-CAST_TYPE_AUDIO = "audio"
-# Cast Audio group device, supports only audio
-CAST_TYPE_GROUP = "group"
-
-CAST_TYPES = {
-    "chromecast": CAST_TYPE_CHROMECAST,
-    "eureka dongle": CAST_TYPE_CHROMECAST,
-    "chromecast audio": CAST_TYPE_AUDIO,
-    "google home": CAST_TYPE_AUDIO,
-    "google home mini": CAST_TYPE_AUDIO,
-    "google cast group": CAST_TYPE_GROUP,
-}
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -90,60 +74,18 @@ def get_device_status(host, services=None, zconf=None):
         status = _get_status(host, services, zconf, "/setup/eureka_info?options=detail")
 
         friendly_name = status.get("name", "Unknown Chromecast")
+        # model_name and manufacturer is no longer included in the response,
+        # mark as unknown
         model_name = "Unknown model name"
         manufacturer = "Unknown manufacturer"
-        if "detail" in status:
-            model_name = status["detail"].get("model_name", model_name)
-            manufacturer = status["detail"].get("manufacturer", manufacturer)
 
         udn = status.get("ssdp_udn", None)
-
-        cast_type = CAST_TYPES.get(model_name.lower(), CAST_TYPE_CHROMECAST)
 
         uuid = None
         if udn:
             uuid = UUID(udn.replace("-", ""))
 
         return DeviceStatus(friendly_name, model_name, manufacturer, uuid, cast_type)
-
-    except (requests.exceptions.RequestException, OSError, ValueError):
-        return None
-
-
-def get_multizone_status(host, services=None, zconf=None):
-    """
-    :param host: Hostname or ip to fetch status from
-    :type host: str
-    :return: The multizone status as a named tuple.
-    :rtype: pychromecast.dial.MultizoneStatus or None
-    """
-
-    try:
-        status = status = _get_status(
-            host, services, zconf, "/setup/eureka_info?params=multizone"
-        )
-
-        dynamic_groups = []
-        if "multizone" in status and "dynamic_groups" in status["multizone"]:
-            for group in status["multizone"]["dynamic_groups"]:
-                name = group.get("name", "Unknown group name")
-                udn = group.get("uuid", None)
-                uuid = None
-                if udn:
-                    uuid = UUID(udn.replace("-", ""))
-                dynamic_groups.append(MultizoneInfo(name, uuid))
-
-        groups = []
-        if "multizone" in status and "groups" in status["multizone"]:
-            for group in status["multizone"]["groups"]:
-                name = group.get("name", "Unknown group name")
-                udn = group.get("uuid", None)
-                uuid = None
-                if udn:
-                    uuid = UUID(udn.replace("-", ""))
-                groups.append(MultizoneInfo(name, uuid))
-
-        return MultizoneStatus(dynamic_groups, groups)
 
     except (requests.exceptions.RequestException, OSError, ValueError):
         return None

--- a/pychromecast/socket_client.py
+++ b/pychromecast/socket_client.py
@@ -23,7 +23,7 @@ from struct import pack, unpack
 from . import cast_channel_pb2
 from .controllers import BaseController
 from .controllers.media import MediaController
-from .dial import CAST_TYPE_CHROMECAST, CAST_TYPE_AUDIO, CAST_TYPE_GROUP
+from .const import CAST_TYPE_AUDIO, CAST_TYPE_CHROMECAST, CAST_TYPE_GROUP
 from .discovery import get_info_from_service, get_host_from_service_info
 from .error import (
     ChromecastConnectionError,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_description = open("README.rst").read()
 
 setup(
     name="PyChromecast",
-    version="4.2.0",
+    version="4.2.1",
     license="MIT",
     url="https://github.com/balloob/pychromecast",
     author="Paulus Schoutsen",


### PR DESCRIPTION
The response to `<address>:8008/setup/eureka_info` no longer includes information about manufacturer, model name or multizone (speaker group) status.

Update the code accordingly:
- `dial.get_device_status` no longer tries to set `model_name` or `manufacturer`. `model_name` and `manufacturer` left in the response though to make the change not break old code
- remove `dial.get_multizone_status`
- add `const.CAST_MANUFACTURERS` to map `model_name` from mdns to manufacturer